### PR TITLE
Better OGP support

### DIFF
--- a/adjunct/ogp.py
+++ b/adjunct/ogp.py
@@ -54,3 +54,13 @@ def to_meta(props: t.Union[Property, t.Sequence[Property]]) -> str:
     if isinstance(props, Property):
         return props.to_meta()
     return "\n".join(prop.to_meta() for prop in props)
+
+
+def find(
+    props: t.Sequence[Property],
+    type_: str,
+    value: t.Optional[str] = None,
+) -> t.Iterable[Property]:
+    for prop in props:
+        if prop.type_ == type_ and (value is None or prop.value == value):
+            yield prop

--- a/adjunct/ogp.py
+++ b/adjunct/ogp.py
@@ -29,10 +29,10 @@ class Property:
         lines = [
             f'<meta property="og:{html.escape(self.type_)}" content="{html.escape(self.value)}">',
         ]
-        for key, value in self.metadata.items():
-            lines.append(
-                f'<meta property="og:{html.escape(self.type_)}:{html.escape(key)}" content="{html.escape(value)}">',
-            )
+        lines.extend(
+            f'<meta property="og:{html.escape(self.type_)}:{html.escape(key)}" content="{html.escape(value)}">'
+            for key, value in self.metadata.items()
+        )
         return "\n".join(lines)
 
 
@@ -44,7 +44,7 @@ def parse(properties: t.Sequence[t.Tuple[str, str]]) -> t.Sequence[Property]:
             result.append(Property(name_parts[1], value, {}))
         if len(name_parts) == 3:
             # Skip any bad metadata
-            if len(result) == 0 or result[-1].type_ != name_parts[1]:
+            if not result or result[-1].type_ != name_parts[1]:
                 continue
             result[-1].metadata[name_parts[2]] = value
     return result

--- a/adjunct/ogp.py
+++ b/adjunct/ogp.py
@@ -4,120 +4,53 @@ An intensely pragmatic implementation of the Open Graph Protocol.
 This follows `the specification <https://opengraphprotocol.org/>`_ rather than
 attempting to implement RDFa.
 
-In spite of the name, it's really just a tree with named edges.
+# Theory of Operation
+
+The metadata consists of a list of properties. A property may be unstructured
+(a string) or structured (a list of properties). A property may appear more
+than once. Properties has the form "ns:name", while a metadata field to be
+attached to a property (thus making it structured) has the form "ns:name:meta".
+
+Metadata should be implemented as a multimap, but I'll be treating it as a map.
 """
 
-import collections
+import dataclasses
 import html
+import typing as t
 
 
-class SingleValue:
+@dataclasses.dataclass
+class Property:
+    type_: str
+    value: str
+    metadata: t.Dict[str, str]
 
-    __slots__ = [
-        "content",
-        "attrs",
-    ]
-
-    def __init__(self, content=None):
-        self.content = content
-        self.attrs = collections.defaultdict(SingleValue)
-
-    def append(self, content):
-        if self.content is None:
-            self.content = content
-            return self
-        return MultiValue(self, content)
-
-    def __len__(self):
-        return 1
-
-    def __str__(self):
-        return self.content
-
-    def __iter__(self):
-        return iter([self])
-
-    def flatten(self):
-        for key, value in self.attrs.items():
-            yield from value._flatten(key)
-
-    def to_meta(self):
-        return "\n".join(
-            f'<meta property="{html.escape(key)}" content="{html.escape(value)}">'
-            for key, value in self.flatten()
-        )
-
-    def _flatten(self, prefix):
-        if self.content is not None:
-            yield (prefix, self.content)
-        for key, value in self.attrs.items():
-            yield from value._flatten(f"{prefix}:{key}")
+    def to_meta(self) -> str:
+        lines = [
+            f'<meta property="og:{html.escape(self.type_)}" content="{html.escape(self.value)}">',
+        ]
+        for key, value in self.metadata.items():
+            lines.append(
+                f'<meta property="og:{html.escape(self.type_)}:{html.escape(key)}" content="{html.escape(value)}">',
+            )
+        return "\n".join(lines)
 
 
-class MultiValue:
-
-    __slots__ = [
-        "_values",
-    ]
-
-    def __init__(self, orig, appended):
-        self._values = [orig]
-        self.append(appended)
-
-    def append(self, content):
-        self._values.append(SingleValue(content))
-        return self
-
-    def __len__(self):
-        return len(self._values)
-
-    def __str__(self):
-        return ", ".join(self._values)
-
-    def __iter__(self):
-        return iter(self._values)
-
-    @property
-    def attrs(self):
-        return self._values[-1].attrs
-
-    def _flatten(self, prefix):
-        for value in self._values:
-            yield from value._flatten(prefix)
+def parse(properties: t.Sequence[t.Tuple[str, str]]) -> t.Sequence[Property]:
+    result = []
+    for name, value in properties:
+        name_parts = name.split(":", 2)
+        if len(name_parts) == 2:
+            result.append(Property(name_parts[1], value, {}))
+        if len(name_parts) == 3:
+            # Skip any bad metadata
+            if len(result) == 0 or result[-1].type_ != name_parts[1]:
+                continue
+            result[-1].metadata[name_parts[2]] = value
+    return result
 
 
-class Root(SingleValue):
-    def insert(self, prop, content):
-        """
-        Break apart a property name and insert the content into the 'graph'.
-        """
-        prev = None
-        node = self
-        key = None  # Keep pylint happy
-        for key in prop.split(":"):
-            prev, node = node, node.attrs[key]
-        # This is safe: there will always be at least one previous node, namely
-        # the root.
-        prev.attrs[key] = node.append(content)
-
-    def get_all(self, prop):
-        node = self
-        for key in prop.split(":"):
-            node = node.attrs[key]
-        yield from node
-
-    def get(self, prop) -> SingleValue:
-        last = None
-        for item in self.get_all(prop):
-            last = item
-        return last
-
-    def __str__(self):
-        return self.to_meta()
-
-    @classmethod
-    def from_list(cls, lst):
-        root = cls()
-        for prop, content in lst:
-            root.insert(prop, content)
-        return root
+def to_meta(props: t.Union[Property, t.Sequence[Property]]) -> str:
+    if isinstance(props, Property):
+        return props.to_meta()
+    return "\n".join(prop.to_meta() for prop in props)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ check = [
 	"black --check --diff .",
 	"isort --check-only --diff .",
 	"pylint adjunct",
-	# "mypy .",
+	"mypy .",
 ]
 fmt = [
 	"isort .",

--- a/tests/ogp-flatten.html
+++ b/tests/ogp-flatten.html
@@ -1,8 +1,0 @@
-<meta property="og:title" content="Testing">
-<meta property="og:title" content="Testing Again">
-<meta property="og:video" content="http://example.com/video1.mpg">
-<meta property="og:video:height" content="52">
-<meta property="og:video:width" content="25">
-<meta property="og:video" content="http://example.com/video2.mpg">
-<meta property="og:video:height" content="64">
-<meta property="og:video:width" content="46">

--- a/tests/ogp-minotaur-shock.html
+++ b/tests/ogp-minotaur-shock.html
@@ -9,8 +9,3 @@
 <meta property="og:video:type" content="text/html">
 <meta property="og:video:height" content="120">
 <meta property="og:video:width" content="400">
-<meta property="twitter:site" content="@bandcamp">
-<meta property="twitter:card" content="player">
-<meta property="twitter:player" content="https://bandcamp.com/EmbeddedPlayer/v=2/track=1335882601/size=large/linkcol=0084B4/notracklist=true/twittercard=true/">
-<meta property="twitter:player:height" content="467">
-<meta property="twitter:player:width" content="350">

--- a/tests/ogp.html
+++ b/tests/ogp.html
@@ -14,8 +14,6 @@
   <meta property="og:type" content="song">
   <meta property="og:site_name" content="Minotaur Shock">
   <meta property="og:description" content="from the album Orchard">
-  <meta property="twitter:site" content="@bandcamp">
-  <meta property="twitter:card" content="player">
   <meta property="og:image" content="https://f4.bcbits.com/img/a3081644212_5.jpg">
   <meta property="og:url" content="https://minotaurshock.bandcamp.com/track/ocean-swell">
   <meta name="generator" content="Bandcamp">
@@ -28,8 +26,5 @@
   <meta property="og:video:type" content="text/html">
   <meta property="og:video:height" content="120">
   <meta property="og:video:width" content="400">
-  <meta property="twitter:player" content="https://bandcamp.com/EmbeddedPlayer/v=2/track=1335882601/size=large/linkcol=0084B4/notracklist=true/twittercard=true/">
-  <meta property="twitter:player:height" content="467">
-  <meta property="twitter:player:width" content="350">
 </head>
 </html>

--- a/tests/test_ogp.py
+++ b/tests/test_ogp.py
@@ -6,78 +6,35 @@ from adjunct import discovery, ogp
 HERE = os.path.dirname(__file__)
 
 
-def load_fixture(name: str) -> str:
-    with open(os.path.join(HERE, name), "r") as fh:
-        return fh.read().strip()
-
-
 class TestOPG(unittest.TestCase):
     maxDiff = None
 
     def setUp(self):
         with open(os.path.join(HERE, "ogp.html"), "rb") as fh:
-            self.properties = discovery.Extractor.extract(fh).properties
-        self.root = ogp.parse(self.properties)
+            self.raw_properties = discovery.Extractor.extract(fh).properties
+        self.properties = ogp.parse(self.raw_properties)
 
     def test_size(self):
-        self.assertEqual(len(self.properties), 11)
+        self.assertEqual(len(self.raw_properties), 11)
+        self.assertEqual(len(self.properties), 7)
 
-    """
     def test_access(self):
-        self.assertSetEqual(set(self.root.attrs.keys()), {"og", "twitter"})
-        self.assertEqual(str(self.root.get("og:type")), "song")
+        self.assertEqual(len(list(ogp.find(self.properties, "type", "song"))), 1)
 
     def test_invalid(self):
-        elem = self.root.get("og:audio")
-        self.assertEqual(len(elem), 1)
-        self.assertIsInstance(elem, ogp.SingleValue)
-        self.assertIsNone(elem.content)
-        self.assertDictEqual(elem.attrs, {})
+        self.assertEqual(len(list(ogp.find(self.properties, "audio"))), 0)
 
     def test_video(self):
-        videos = list(self.root.get_all("og:video"))
+        videos = list(ogp.find(self.properties, "video"))
         self.assertEqual(len(videos), 1)
-        attrs = dict(videos[0].flatten())
-        self.assertEqual(videos[0].content, attrs["secure_url"])
+        self.assertEqual(videos[0].value, videos[0].metadata["secure_url"])
         self.assertSetEqual(
-            set(attrs.keys()),
+            set(videos[0].metadata.keys()),
             {"secure_url", "type", "width", "height"},
         )
-    """
 
     def test_meta(self):
-        meta = ogp.to_meta(self.root)
-        expected = load_fixture("ogp-minotaur-shock.html")
-        self.assertEqual(meta, expected)
-
-
-class TestMultiValue(unittest.TestCase):
-    maxDiff = None
-
-    def setUp(self):
-        properties = [
-            ("og:title", "Testing"),
-            ("og:title", "Testing Again"),
-            ("og:video", "http://example.com/video1.mpg"),
-            ("og:video:height", "52"),
-            ("og:video:width", "25"),
-            ("og:video", "http://example.com/video2.mpg"),
-            ("og:video:height", "64"),
-            ("og:video:width", "46"),
-        ]
-        self.root = ogp.parse(properties)
-
-    """
-    def test_multivalue(self):
-        items = list(self.root.get_all("og:title"))
-        self.assertEqual(len(items), 2)
-        self.assertListEqual(
-            [str(item) for item in items],
-            ["Testing", "Testing Again"],
-        )
-    """
-
-    def test_flatten(self):
-        meta = ogp.to_meta(self.root)
-        expected = load_fixture("ogp-flatten.html")
+        meta = ogp.to_meta(self.properties)
+        with open(os.path.join(HERE, "ogp-minotaur-shock.html"), "r") as fh:
+            expected = fh.read().strip()
         self.assertEqual(meta, expected)

--- a/tests/test_ogp.py
+++ b/tests/test_ogp.py
@@ -12,15 +12,17 @@ def load_fixture(name: str) -> str:
 
 
 class TestOPG(unittest.TestCase):
+    maxDiff = None
+
     def setUp(self):
         with open(os.path.join(HERE, "ogp.html"), "rb") as fh:
             self.properties = discovery.Extractor.extract(fh).properties
-        self.root = ogp.Root.from_list(self.properties)
+        self.root = ogp.parse(self.properties)
 
     def test_size(self):
-        self.assertEqual(len(self.properties), 16)
-        self.assertEqual(len(self.properties), len(list(self.root.flatten())))
+        self.assertEqual(len(self.properties), 11)
 
+    """
     def test_access(self):
         self.assertSetEqual(set(self.root.attrs.keys()), {"og", "twitter"})
         self.assertEqual(str(self.root.get("og:type")), "song")
@@ -28,8 +30,6 @@ class TestOPG(unittest.TestCase):
     def test_invalid(self):
         elem = self.root.get("og:audio")
         self.assertEqual(len(elem), 1)
-        # Ensure this doesn't add anything
-        self.assertEqual(len(self.properties), len(list(self.root.flatten())))
         self.assertIsInstance(elem, ogp.SingleValue)
         self.assertIsNone(elem.content)
         self.assertDictEqual(elem.attrs, {})
@@ -43,14 +43,17 @@ class TestOPG(unittest.TestCase):
             set(attrs.keys()),
             {"secure_url", "type", "width", "height"},
         )
+    """
 
     def test_meta(self):
-        meta = str(self.root)
+        meta = ogp.to_meta(self.root)
         expected = load_fixture("ogp-minotaur-shock.html")
-        self.assertEqual(meta.strip(), expected)
+        self.assertEqual(meta, expected)
 
 
 class TestMultiValue(unittest.TestCase):
+    maxDiff = None
+
     def setUp(self):
         properties = [
             ("og:title", "Testing"),
@@ -62,8 +65,9 @@ class TestMultiValue(unittest.TestCase):
             ("og:video:height", "64"),
             ("og:video:width", "46"),
         ]
-        self.root = ogp.Root.from_list(properties)
+        self.root = ogp.parse(properties)
 
+    """
     def test_multivalue(self):
         items = list(self.root.get_all("og:title"))
         self.assertEqual(len(items), 2)
@@ -71,8 +75,9 @@ class TestMultiValue(unittest.TestCase):
             [str(item) for item in items],
             ["Testing", "Testing Again"],
         )
+    """
 
     def test_flatten(self):
-        meta = str(self.root)
+        meta = ogp.to_meta(self.root)
         expected = load_fixture("ogp-flatten.html")
-        self.assertEqual(meta.strip(), expected)
+        self.assertEqual(meta, expected)


### PR DESCRIPTION
This is a ground-up rewrite to make things a bit more sensible. It doesn't as yet support namespaces and assumes to 'og' prefix, nor does it allow the duplication of metadata properties outside of the top level, but it's also a lot less clever-janky than the old code.

At some point, I may reintroduce namespace support, but not yet.