### PR TITLE
Increase test coverage and fix some types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,9 @@ __pycache__/
 dist/
 
 # Unit test / coverage reports
-.coverage
+.coverage*
 htmlcov/
-tests/results.xml
+results.xml
 .*_cache/
 
 # General detritus

--- a/src/adjunct/compat.py
+++ b/src/adjunct/compat.py
@@ -1,7 +1,7 @@
 import typing as t
 
 
-def parse_header(line: str) -> t.Tuple[str, t.Dict[str, str]]:
+def parse_header(line: str) -> tuple[str, dict[str, str]]:
     """
     Parse a Content-type like header.
 

--- a/src/adjunct/discoverfeeds.py
+++ b/src/adjunct/discoverfeeds.py
@@ -2,7 +2,6 @@
 Feed discovery.
 """
 
-
 from . import discovery
 
 __all__ = ["discover_feeds"]
@@ -29,7 +28,7 @@ class FeedExtractor(discovery.Extractor):
 
     def __init__(self, base: str):
         super().__init__(base)
-        self.anchor = None
+        self.anchor: dict[str, str] | None = None
         self.added: set[str] = set()
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]):

--- a/src/adjunct/fixtureutils.py
+++ b/src/adjunct/fixtureutils.py
@@ -32,7 +32,7 @@ def fixture(app, *, returns_app: bool = False, timeout: int = 5):
     Set `returns_app` if `app` is a callable that returns the actual app (such
     as a class).
     """
-    queue = multiprocessing.Queue()
+    queue: multiprocessing.Queue[tuple[str, int]] = multiprocessing.Queue()
 
     # Spin up a separate process for our fixture server.
     proc = multiprocessing.Process(target=start_server, args=(app, queue, returns_app))

--- a/src/adjunct/fixtureutils.py
+++ b/src/adjunct/fixtureutils.py
@@ -24,7 +24,7 @@ def start_server(app, queue, returns_app):
 
 
 @contextlib.contextmanager
-def fixture(app, *, returns_app=False):
+def fixture(app, *, returns_app: bool = False, timeout: int = 5):
     """
     Start the given application fixture in its own process, yielding a socket
     connected to it.
@@ -41,7 +41,7 @@ def fixture(app, *, returns_app=False):
         raise RuntimeError(f"{app} didn't start")
 
     try:
-        hostname, port = queue.get(timeout=5)
+        hostname, port = queue.get(timeout=timeout)
         yield f"http://{hostname}:{port}/"
     finally:
         if proc.exitcode is None:
@@ -73,14 +73,6 @@ def extract_environment(environ):
         "REQUEST_METHOD",
     ]
     return {key: value for key, value in environ.items() if key in non_http or key.startswith("HTTP_")}
-
-
-def _al_contains(al, key):
-    """
-    Treating `al` as an association list (a list of two-tuples), return `True`
-    if `key` is a key value.
-    """
-    return any(k == key for k, _ in al)
 
 
 def response(start_response, code, body="", headers=None):
@@ -134,7 +126,7 @@ def make_fake_http_response_msg(code=200, body="", headers=None):
             value, params = value
             msg.add_header(key, value, **params)
         else:
-            msg.add_header(key, value)
+            msg.add_header(key, value)  # type: ignore
     if not has_content_type:
         msg.add_header("Content-Type", "application/octet-stream")
     status = f"HTTP/1.0 {code} {client.responses[code]}\r\n"

--- a/src/adjunct/oembed.py
+++ b/src/adjunct/oembed.py
@@ -21,7 +21,7 @@ class OEmbedContentHandler(xml.sax.handler.ContentHandler):
     Pulls the fields out of an XML oEmbed document.
     """
 
-    valid_fields: t.ClassVar[t.List[str]] = [
+    valid_fields: t.ClassVar[list[str]] = [
         "type",
         "version",
         "title",
@@ -103,7 +103,7 @@ def fetch_oembed_document(
     return None
 
 
-def _parse_xml_oembed_response(fh: t.TextIO) -> t.Dict[str, str | int]:
+def _parse_xml_oembed_response(fh: t.TextIO) -> dict[str, str | int]:
     """
     Parse the fields from an XML OEmbed document.
     """

--- a/src/adjunct/ogp.py
+++ b/src/adjunct/ogp.py
@@ -29,7 +29,7 @@ import typing as t
 class Property:
     type_: str
     value: str
-    metadata: t.Dict[str, str]
+    metadata: dict[str, str]
 
     def to_meta(self) -> str:
         lines = [
@@ -42,7 +42,7 @@ class Property:
         return "\n".join(lines)
 
 
-def parse(properties: t.Collection[t.Tuple[str, str]]) -> t.Sequence[Property]:
+def parse(properties: t.Collection[tuple[str, str]]) -> t.Sequence[Property]:
     result = []
     for name, value in properties:
         name_parts = name.split(":", 2)

--- a/src/adjunct/recaptcha.py
+++ b/src/adjunct/recaptcha.py
@@ -4,7 +4,6 @@ A reCAPTCHA_ client library.
 .. _reCAPTCHA: http://www.google.com/recaptcha
 """
 
-import typing as t
 from urllib import parse, request
 
 __all__ = ["check", "make_markup"]
@@ -39,7 +38,7 @@ def check(
     remote_ip: str,
     challenge: str,
     response: str,
-) -> t.Tuple[bool, str]:
+) -> tuple[bool, str]:
     """
     Validate the CAPTCHA response.
     """

--- a/tests/test_discoverfeeds.py
+++ b/tests/test_discoverfeeds.py
@@ -1,0 +1,58 @@
+from adjunct import discoverfeeds, fixtureutils
+
+
+def test_discover_feeds():
+    def app(environ, start_response):  # noqa: ARG001
+        headers = [
+            ("Content-Type", "text/html; charset=utf-8"),
+        ]
+        start_response("200 OK", headers)
+        return [
+            b"""<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="alternate" type="application/rss+xml" title="RSS" href="/feeds/rss">
+        <link rel="alternate" type="application/atom+xml" title="Atom" href="/feeds/atom">
+    </head>
+</html>"""
+        ]
+
+    with fixtureutils.fixture(app) as addr:
+        feeds = discoverfeeds.discover_feeds(addr)
+        # Note: feeds are returned in priority order.
+        assert feeds == [
+            {"type": "application/atom+xml", "title": "Atom", "href": f"{addr}feeds/atom"},
+            {"type": "application/rss+xml", "title": "RSS", "href": f"{addr}feeds/rss"},
+        ]
+
+
+def test_discover_feeds_anchors():
+    def app(environ, start_response):  # noqa: ARG001
+        headers = [
+            ("Content-Type", "text/html; charset=utf-8"),
+        ]
+        start_response("200 OK", headers)
+        return [
+            b"""<!DOCTYPE html>
+<html>
+    <head>
+    </head>
+    <body>
+        <a href="/feeds/rss">RSS Feed</a>
+        <a href="/feeds/atom">Atom Feed</a>
+        <a href="/feeds/rss.xml">RSS Feed</a>
+        <a href="/feed.rdf">RDF Feed</a>
+        <a href="/feed.xoxo">XOXO Feed</a>
+        <a>Not a feed, not even a link</a>
+</html>"""
+        ]
+
+    with fixtureutils.fixture(app) as addr:
+        feeds = discoverfeeds.discover_feeds(addr)
+        # Note: feeds are returned in priority order.
+        assert feeds == [
+            {"type": "application/atom+xml", "title": "Atom Feed", "href": f"{addr}feeds/atom"},
+            {"type": "application/rdf+xml", "title": "RDF Feed", "href": f"{addr}feed.rdf"},
+            {"type": "application/rss+xml", "title": "RSS Feed", "href": f"{addr}feeds/rss"},
+            {"type": "application/rss+xml", "title": "RSS Feed", "href": f"{addr}feeds/rss.xml"},
+        ]

--- a/tests/test_discoverfeeds.py
+++ b/tests/test_discoverfeeds.py
@@ -1,23 +1,24 @@
 from adjunct import discoverfeeds, fixtureutils
 
 
-def test_discover_feeds():
-    def app(environ, start_response):  # noqa: ARG001
-        headers = [
-            ("Content-Type", "text/html; charset=utf-8"),
-        ]
-        start_response("200 OK", headers)
-        return [
-            b"""<!DOCTYPE html>
+def app_discover_feeds(environ, start_response):  # noqa: ARG001
+    headers = [
+        ("Content-Type", "text/html; charset=utf-8"),
+    ]
+    start_response("200 OK", headers)
+    return [
+        b"""<!DOCTYPE html>
 <html>
     <head>
         <link rel="alternate" type="application/rss+xml" title="RSS" href="/feeds/rss">
         <link rel="alternate" type="application/atom+xml" title="Atom" href="/feeds/atom">
     </head>
 </html>"""
-        ]
+    ]
 
-    with fixtureutils.fixture(app) as addr:
+
+def test_discover_feeds():
+    with fixtureutils.fixture(app_discover_feeds) as addr:
         feeds = discoverfeeds.discover_feeds(addr)
         # Note: feeds are returned in priority order.
         assert feeds == [
@@ -26,14 +27,13 @@ def test_discover_feeds():
         ]
 
 
-def test_discover_feeds_anchors():
-    def app(environ, start_response):  # noqa: ARG001
-        headers = [
-            ("Content-Type", "text/html; charset=utf-8"),
-        ]
-        start_response("200 OK", headers)
-        return [
-            b"""<!DOCTYPE html>
+def app_discover_feeds_anchors(environ, start_response):  # noqa: ARG001
+    headers = [
+        ("Content-Type", "text/html; charset=utf-8"),
+    ]
+    start_response("200 OK", headers)
+    return [
+        b"""<!DOCTYPE html>
 <html>
     <head>
     </head>
@@ -45,9 +45,11 @@ def test_discover_feeds_anchors():
         <a href="/feed.xoxo">XOXO Feed</a>
         <a>Not a feed, not even a link</a>
 </html>"""
-        ]
+    ]
 
-    with fixtureutils.fixture(app) as addr:
+
+def test_discover_feeds_anchors():
+    with fixtureutils.fixture(app_discover_feeds_anchors) as addr:
         feeds = discoverfeeds.discover_feeds(addr)
         # Note: feeds are returned in priority order.
         assert feeds == [

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -42,23 +42,24 @@ class ExtractorTest(unittest.TestCase):
         )
 
 
-def test_fetch_meta():
-    def meta_app(environ, start_response):  # noqa: ARG001
-        headers = [
-            ("Content-Type", "text/html; charset=utf-8"),
-            ("Link", '<http://example.com/>; rel="bar"'),
-        ]
-        start_response("200 OK", headers)
-        return [
-            b"""<!DOCTYPE html>
+def meta_app(environ, start_response):  # noqa: ARG001
+    headers = [
+        ("Content-Type", "text/html; charset=utf-8"),
+        ("Link", '<http://example.com/>; rel="bar"'),
+    ]
+    start_response("200 OK", headers)
+    return [
+        b"""<!DOCTYPE html>
 <html>
     <head>
         <link rel="foo" href="bar">
         <meta property="og:title" content="Example">
     </head>
 </html>"""
-        ]
+    ]
 
+
+def test_fetch_meta():
     with fixtureutils.fixture(meta_app) as addr:
         links, properties = discovery.fetch_meta(addr)
         assert links == [

--- a/tests/test_fixtureutils.py
+++ b/tests/test_fixtureutils.py
@@ -1,0 +1,79 @@
+import urllib.request
+
+from adjunct import fixtureutils
+
+
+def test_make_fake_http_response_msg():
+    msg = fixtureutils.make_fake_http_response_msg(
+        code=404,
+        body="Not Found",
+        headers={"Content-Type": "text/plain"},
+    )
+    assert msg == b"HTTP/1.0 404 Not Found\r\nContent-Length: 9\nContent-Type: text/plain\n\nNot Found"
+
+
+def test_make_fake_http_response_msg_complex_header():
+    msg = fixtureutils.make_fake_http_response_msg(
+        code=404,
+        body="Not Found",
+        headers={"Content-Type": ("text/plain", {"charset": "UTF-8"})},
+    )
+    assert msg == b'HTTP/1.0 404 Not Found\r\nContent-Length: 9\nContent-Type: text/plain; charset="UTF-8"\n\nNot Found'
+
+
+def test_make_fake_http_response_msg_no_content_type():
+    msg = fixtureutils.make_fake_http_response_msg(
+        code=404,
+        body="Not Found",
+    )
+    assert msg == b"HTTP/1.0 404 Not Found\r\nContent-Length: 9\nContent-Type: application/octet-stream\n\nNot Found"
+
+
+def test_make_fake_http_response():
+    response = fixtureutils.make_fake_http_response(
+        body="Hello, World!",
+        code=200,
+        headers={
+            "Content-Type": "text/plain",
+            "X-Custom-Header": "CustomValue",
+        },
+    )
+    assert response.status == 200
+    assert response.getheader("Content-Type") == "text/plain"
+    assert response.getheader("X-Custom-Header") == "CustomValue"
+    assert response.read() == b"Hello, World!"
+
+
+def test_json_response():
+    response_status = ""
+    response_headers = []
+
+    def start_response(status, headers):
+        nonlocal response_status, response_headers
+        response_status = status
+        response_headers = headers
+
+    result = fixtureutils.json_response(start_response, {"key": "value"})
+
+    assert response_status.startswith("200")
+    headers_dict = dict(response_headers)
+    assert headers_dict["Content-Type"] == "application/json; charset=UTF-8"
+    assert "".join(result) == '{"key": "value"}'
+
+
+def fixture_app(environ, start_response):  # noqa: ARG001
+    """
+    A simple WSGI application for testing purposes.
+    """
+    status = "200 OK"
+    headers = [("Content-Type", "text/plain; charset=UTF-8")]
+    start_response(status, headers)
+    return [b"Fixture App Response"]
+
+
+def test_fixture():
+    with fixtureutils.fixture(fixture_app) as addr, urllib.request.urlopen(addr) as resp:
+        body = resp.read()
+        assert resp.status == 200
+        assert resp.getheader("Content-Type") == "text/plain; charset=UTF-8"
+        assert body == b"Fixture App Response"

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -82,3 +82,10 @@ class TestElement(unittest.TestCase):
             "<a name>bar</a>",
             "<a name>bar</a>",
         )
+
+
+def test_make_html():
+    assert html.make("br", attrs={}) == "<br>"
+    assert html.make("a", attrs={"href": "foo"}) == '<a href="foo"></a>'
+    assert html.make("a", attrs={"href": "foo"}, close=False) == '<a href="foo">'
+    assert html.make("input", attrs={"type": "checkbox", "disabled": None}) == '<input type="checkbox" disabled>'

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py311,py312,py313,py314
+
+[testenv]
+runner = uv-venv-lock-runner
+changedir = tests
+deps = pytest
+commands = pytest --basetemp="{envtmpdir}" {posargs}


### PR DESCRIPTION
## Summary by Sourcery

Improve internal type annotations and extend test coverage for discovery, feed discovery, fixture utilities, HTML helpers, and other modules

Enhancements:
- Replace typing module imports and `t.*` annotations with built-in generics across multiple modules
- Refine FeedExtractor to separate feed type detection and attribute normalization
- Add `timeout` parameter to fixtureutils.fixture and remove an unused helper

Tests:
- Expand test suite to cover discovery.fetch_meta and discovery.safe_slurp
- Add tests for HTML.make utility, fixtureutils responses and server fixture, and discoverfeeds.discover_feeds behavior
- Update existing tests to use discovery.Extractor instead of direct imports