### PR TITLE
More tests and type annotations

### DIFF
--- a/src/adjunct/fixtureutils.py
+++ b/src/adjunct/fixtureutils.py
@@ -8,6 +8,7 @@ import io
 import json
 import multiprocessing
 from wsgiref.simple_server import make_server
+import typing as t
 
 
 def start_server(app, queue, returns_app):  # pragma: no cover
@@ -77,7 +78,12 @@ def extract_environment(environ: dict) -> dict:
     return {key: value for key, value in environ.items() if key in non_http or key.startswith("HTTP_")}
 
 
-def response(start_response, code: int, body: str = "", headers=None) -> list[bytes | str]:
+def response(
+    start_response,
+    code: int,
+    body: bytes = b"",
+    headers: list[tuple[str, str]] | None = None,
+) -> t.Iterable[bytes]:
     if headers is None:
         headers = []
     headers.append(("Content-Length", str(len(body))))
@@ -85,14 +91,14 @@ def response(start_response, code: int, body: str = "", headers=None) -> list[by
     return [body]
 
 
-def json_response(start_response, body, headers=None) -> list[bytes | str]:
+def json_response(start_response, body) -> t.Iterable[bytes]:
     headers = [("Content-Type", "application/json; charset=UTF-8")]
-    return response(start_response, 200, body=json.dumps(body), headers=headers)
+    return response(start_response, 200, body=json.dumps(body).encode("utf-8"), headers=headers)
 
 
-def basic_response(start_response, code: int, body: str = "") -> list[bytes | str]:
+def basic_response(start_response, code: int, body: str = "") -> t.Iterable[bytes]:
     headers = [("Content-Type", "text/plain; charset=UTF-8")]
-    return response(start_response, code, body, headers=headers)
+    return response(start_response, code, body.encode("utf-8"), headers=headers)
 
 
 class FakeSocket:

--- a/src/adjunct/fixtureutils.py
+++ b/src/adjunct/fixtureutils.py
@@ -7,8 +7,8 @@ from http import client
 import io
 import json
 import multiprocessing
-from wsgiref.simple_server import make_server
 import typing as t
+from wsgiref.simple_server import make_server
 
 
 def start_server(app, queue, returns_app):  # pragma: no cover

--- a/src/adjunct/fixtureutils.py
+++ b/src/adjunct/fixtureutils.py
@@ -10,13 +10,15 @@ import multiprocessing
 from wsgiref.simple_server import make_server
 
 
-def start_server(app, queue, returns_app):
+def start_server(app, queue, returns_app):  # pragma: no cover
     """
     Run a fixture application.
     """
-    # 'app' is actually a callable that returns an app. Useful when dealing
-    # with a app implemented as a class.
+    # This is excluded from coverage as it's only run in a separate process.
+    # If there were an issue, the tests using fixtures would fail.
     if returns_app:
+        # 'app' is actually a callable that returns an app. Useful when dealing
+        # with a app implemented as a class.
         app = app()
     svr = make_server("localhost", 0, app)
     queue.put(("localhost", svr.server_port))
@@ -49,22 +51,22 @@ def fixture(app, *, returns_app: bool = False, timeout: int = 5):
         queue.close()
 
 
-def get_content_length(environ):
-    content_length = environ.get("CONTENT_LENGTH", None)
+def get_content_length(environ: dict) -> int | None:
+    content_length = environ.get("CONTENT_LENGTH")
     return None if content_length is None else int(content_length)
 
 
-def read_body(environ):
+def read_body(environ: dict) -> bytes:
     return environ["wsgi.input"].read(get_content_length(environ))
 
 
-def read_json(environ):
+def read_json(environ: dict):
     if environ["CONTENT_TYPE"] == "application/json":
         return json.loads(read_body(environ))
     return None
 
 
-def extract_environment(environ):
+def extract_environment(environ: dict) -> dict:
     non_http = [
         "CONTENT_LENGTH",
         "CONTENT_TYPE",
@@ -75,7 +77,7 @@ def extract_environment(environ):
     return {key: value for key, value in environ.items() if key in non_http or key.startswith("HTTP_")}
 
 
-def response(start_response, code, body="", headers=None):
+def response(start_response, code: int, body: str = "", headers=None) -> list[bytes | str]:
     if headers is None:
         headers = []
     headers.append(("Content-Length", str(len(body))))
@@ -83,12 +85,12 @@ def response(start_response, code, body="", headers=None):
     return [body]
 
 
-def json_response(start_response, body, headers=None):
+def json_response(start_response, body, headers=None) -> list[bytes | str]:
     headers = [("Content-Type", "application/json; charset=UTF-8")]
     return response(start_response, 200, body=json.dumps(body), headers=headers)
 
 
-def basic_response(start_response, code, body=""):
+def basic_response(start_response, code: int, body: str = "") -> list[bytes | str]:
     headers = [("Content-Type", "text/plain; charset=UTF-8")]
     return response(start_response, code, body, headers=headers)
 

--- a/tests/test_fixtureutils.py
+++ b/tests/test_fixtureutils.py
@@ -58,7 +58,7 @@ def test_json_response():
     assert response_status.startswith("200")
     headers_dict = dict(response_headers)
     assert headers_dict["Content-Type"] == "application/json; charset=UTF-8"
-    assert "".join(result) == '{"key": "value"}'
+    assert b"".join(result) == b'{"key": "value"}'
 
 
 def fixture_app(environ, start_response):  # noqa: ARG001


### PR DESCRIPTION
## Summary by Sourcery

Add type annotations to WSGI fixture utilities and enforce byte-encoded responses, adjust coverage comments, update tests for OEmbed error handling and byte-based assertions

Enhancements:
- Add PEP 484 type hints to fixtureutils functions and parameters
- Standardize response, json_response, and basic_response to return byte-encoded bodies

Tests:
- Add tests for fetch_oembed_document handling of 400 and 500 HTTP errors
- Update test_fixtureutils assertion to validate byte output instead of string