### PR TITLE
Avoid scanning test fixture data: can cause false positives

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,5 @@
+---
+ignore:
+  - tests/*.json
+  - tests/*.xml
+  - tests/*.html


### PR DESCRIPTION
The motivator here is that Sourcery has started flagging some test data in `tests/passwd.json` as API keys.

## Summary by Sourcery

Build:
- Ignore tests/*.json, tests/*.xml and tests/*.html in .sourcery.yaml