### PR TITLE
Yet more tests

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -45,6 +45,7 @@ class ExtractorTest(unittest.TestCase):
 def meta_app(environ, start_response):  # noqa: ARG001
     headers = [
         ("Content-Type", "text/html; charset=utf-8"),
+        ("Link", "http://malformed.example.com/"),
         ("Link", '<http://example.com/>; rel="bar"'),
     ]
     start_response("200 OK", headers)

--- a/tests/test_fixtureutils.py
+++ b/tests/test_fixtureutils.py
@@ -1,5 +1,8 @@
 import io
+import json
 import urllib.request
+
+import pytest
 
 from adjunct import fixtureutils
 
@@ -124,3 +127,12 @@ def test_read_json_no_length():
         "wsgi.input": io.BytesIO(payload),
     }
     assert fixtureutils.read_json(env) == {"foo": "bar"}
+
+
+def test_read_json_malformed_json():
+    env = {
+        "CONTENT_TYPE": "application/json",
+        "wsgi.input": io.BytesIO(b'{"key": "value",}'),  # Malformed JSON (trailing comma)
+    }
+    with pytest.raises(json.JSONDecodeError):
+        fixtureutils.read_json(env)

--- a/tests/test_fixtureutils.py
+++ b/tests/test_fixtureutils.py
@@ -1,3 +1,4 @@
+import io
 import urllib.request
 
 from adjunct import fixtureutils
@@ -77,3 +78,49 @@ def test_fixture():
         assert resp.status == 200
         assert resp.getheader("Content-Type") == "text/plain; charset=UTF-8"
         assert body == b"Fixture App Response"
+
+
+def test_extract_environment():
+    env = {
+        "CONTENT_LENGTH": 50,
+        "CONTENT_TYPE": "text/plain",
+        "PATH_INFO": "/foo/bar",
+        "QUERY_STRING": "?foo=bar",
+        "REQUEST_METHOD": "GET",
+        "PATH": "/bin:/usr/bin",
+        "LETS_NOT_LEAK_THIS": "SEKRIT",
+        "HTTP_ACCEPT": "text/html",
+    }
+    extracted = fixtureutils.extract_environment(env)
+    assert set(extracted.keys()) == {
+        "CONTENT_TYPE",
+        "CONTENT_LENGTH",
+        "PATH_INFO",
+        "QUERY_STRING",
+        "REQUEST_METHOD",
+        "HTTP_ACCEPT",
+    }
+
+
+def test_read_json_bad_content_type():
+    env = {"CONTENT_TYPE": "text/plain"}
+    assert fixtureutils.read_json(env) is None
+
+
+def test_read_json():
+    payload = b'{"foo": "bar"}'
+    env = {
+        "CONTENT_TYPE": "application/json",
+        "CONTENT_LENGTH": len(payload),
+        "wsgi.input": io.BytesIO(payload),
+    }
+    assert fixtureutils.read_json(env) == {"foo": "bar"}
+
+
+def test_read_json_no_length():
+    payload = b'{"foo": "bar"}'
+    env = {
+        "CONTENT_TYPE": "application/json",
+        "wsgi.input": io.BytesIO(payload),
+    }
+    assert fixtureutils.read_json(env) == {"foo": "bar"}


### PR DESCRIPTION
This tests the remaining low-hanging fruit in `fixtureutils` and `oembed`, and tests a missed condition for `discovery`.

## Summary by Sourcery

Add tests for remaining low-hanging fruit in fixtureutils and oembed modules and cover a missed discovery condition

Tests:
- Extend oembed tests by defining LINKS_WITH, updating find_first_oembed_link scenarios, and adding get_oembed tests for None and valid responses via mocked urlopen
- Add fixtureutils tests for extract_environment filtering and read_json JSON parsing behavior with wrong content type, with and without CONTENT_LENGTH
- Add a discovery module test to ensure malformed Link headers are properly handled