### PR TITLE
Tooling documentation and config consolidation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,4 +6,28 @@ adjunct
 
 It's intended that this will eventually end up as a namespace package.
 
+Development and Testing
+=======================
+
+You should make sure you've `just <https://just.systems/>`_ installed, as it's
+used for running maintenance tasks
+
+You're expected to make sure you've `uv <https://docs.astral.sh/uv/>`_
+installed as it's used for managing the project. Also, for linting and code
+fixes, make sure you've `ruff <https://docs.astral.sh/ruff/>`_ installed too.
+If you've *uv* installed already, install *ruff* with::
+
+    uv tool install ruff
+
+For normal development, you can run the test suite with::
+
+    just tests
+
+If you want to run the test suite across all supported Python runtimes, you'll
+need `tox <https://tox.wiki/en/4.32.0/>`_. Like with *ruff*, you can install
+it with *uv*. You'll need to make sure that you have the *tox-uv* plugin
+installed too::
+
+    uv tool install tox --with tox-uv
+
 .. vim:set ft=rst:

--- a/justfile
+++ b/justfile
@@ -20,5 +20,10 @@ typecheck:
 
 # clean up any caches or temporary files and directories
 clean:
-	@rm -rf .mypy_cache .pytest_cache .ruff_cache .venv dist htmlcov .coverage
+	@rm -rf .mypy_cache .pytest_cache .ruff_cache .venv dist htmlcov .coverage tests/results.xml .coverage.*
 	@find . -name \*.orig -delete
+
+# install tools (you'll have to ensure you have uv already installed)
+tools:
+	@uv tool install ruff
+	@uv tool install tox --with tox-uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,3 +139,12 @@ exclude_lines = [
 
 [tool.mypy]
 ignore_missing_imports = true
+
+[tool.tox]
+requires = ["tox>=4", "tox-uv>=1"]
+env_list = ["py311", "py312", "py313", "py314"]
+
+[tool.tox.env_run_base]
+runner = "uv-venv-lock-runner"
+description = "Run test under {base_python}"
+commands = [["pytest", "--basetemp={envtmpdir}"]]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[tox]
-envlist = py311,py312,py313,py314
-
-[testenv]
-runner = uv-venv-lock-runner
-changedir = tests
-deps = pytest
-commands = pytest --basetemp="{envtmpdir}" {posargs}


### PR DESCRIPTION
## Summary by Sourcery

Consolidate and streamline development tooling by centralizing configurations in pyproject.toml and enhancing the Justfile, while removing the redundant tox.ini.

Enhancements:
- Move tox configuration from tox.ini into the [tool.tox] section of pyproject.toml and delete tox.ini
- Define multiple Python test environments and specify uv-venv-lock-runner for tox commands
- Expand the Justfile clean recipe to remove additional caches and add a tools recipe to install project tools via uv