### PR TITLE
Documentation for half of the library

### DIFF
--- a/docs/adjunct.totp.md
+++ b/docs/adjunct.totp.md
@@ -37,8 +37,7 @@ user so they can add it to their OTP generator.
 print(t1.to_url("jane.doe@example.com", issuer="Yoyodyne"))
 ```
 
-Finally, to check a code, pass it to `check` method to validate a code provided
-by the user.
+Finally, to check a code, pass it to `check` method to validate a code provided by the user.
 
 ```py
 while True:

--- a/justfile
+++ b/justfile
@@ -27,3 +27,8 @@ clean:
 tools:
 	@uv tool install ruff
 	@uv tool install tox --with tox-uv
+
+# run the mkdocs server
+serve-docs:
+	# --livereload is needed because of https://github.com/squidfunk/mkdocs-material/issues/8478
+	@uv run mkdocs serve --livereload

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,10 @@ plugins:
           options:
             docstring_style: google
 
+watch:
+  - docs
+  - src/adjunct
+
 nav:
   - index.md
   - Reference:

--- a/src/adjunct/compat.py
+++ b/src/adjunct/compat.py
@@ -3,12 +3,15 @@ import typing as t
 
 def parse_header(line: str) -> tuple[str, dict[str, str]]:
     """
-    Parse a Content-type like header.
+    Parse a `Content-Type`-like header.
 
-    Return the main content-type and a dictionary of options.
+    Args:
+        line: a HTTP header line
 
-    Copied, with _parseparam, from Python's cgi module until I can find a
-    better alternative.
+    Returns:
+        The main value and a dictionary of options.
+
+    (Copied from Python's `cgi` module until I can find a better alternative.)
     """
     parts = _parseparam(f";{line}")
     key = parts.__next__()

--- a/src/adjunct/discoverfeeds.py
+++ b/src/adjunct/discoverfeeds.py
@@ -2,25 +2,27 @@
 Feed discovery.
 """
 
+import typing as t
+
 from . import discovery
 
 __all__ = ["discover_feeds"]
 
 
 # Acceptable feed  types, sorted by priority.
-ACCEPTABLE = ["application/atom+xml", "application/rdf+xml", "application/rss+xml"]
+_ACCEPTABLE = ["application/atom+xml", "application/rdf+xml", "application/rss+xml"]
 
 # Used when ordering feeds.
-ORDER = {mimetype: i_type for i_type, mimetype in enumerate(ACCEPTABLE)}
+_ORDER = {mimetype: i_type for i_type, mimetype in enumerate(_ACCEPTABLE)}
 
-GUESSES = {
+_GUESSES = {
     "application/rss+xml": (".rss", "rss.xml", "/rss", "/rss/", "/feed/"),
     "application/rdf+xml": (".rdf", "rdf.xml", "/rdf", "/rdf/"),
     "application/atom+xml": (".atom", "atom.xml", "/atom", "/atom/"),
 }
 
 
-class FeedExtractor(discovery.Extractor):
+class _FeedExtractor(discovery.Extractor):
     """
     Extract any link or anchor elements that look like they might refer to
     feeds.
@@ -33,11 +35,11 @@ class FeedExtractor(discovery.Extractor):
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]):
         if tag.lower() == "a" and self.anchor is None:
-            fixed_attrs = discovery.fix_attributes(attrs)
+            fixed_attrs = discovery._fix_attributes(attrs)
             if "href" in fixed_attrs:
                 fixed_attrs["@data"] = ""
                 feed_type = self.guess_feed_type(fixed_attrs["href"])
-                if feed_type in ACCEPTABLE:
+                if feed_type in _ACCEPTABLE:
                     fixed_attrs.setdefault("type", feed_type)
                     fixed_attrs.setdefault("rel", "feed")
                     self.anchor = fixed_attrs
@@ -54,7 +56,7 @@ class FeedExtractor(discovery.Extractor):
         if tag.lower() == "a" and self.anchor is not None:
             self.anchor.setdefault("title", self.anchor["@data"])
             del self.anchor["@data"]
-            self.append(self.anchor)
+            self._append(self.anchor)
             self.anchor = None
         else:
             super().handle_endtag(tag)
@@ -65,28 +67,34 @@ class FeedExtractor(discovery.Extractor):
         """
         # Reasonable assumption: we're dealing with <a> elements, and by this
         # time, we should've encountered any <base> elements we care about.
-        href = self.fix_href(href)
+        href = self._fix_href(href)
         return next(
-            (mimetype for mimetype, endings in GUESSES.items() if href.lower().endswith(endings)),
+            (mimetype for mimetype, endings in _GUESSES.items() if href.lower().endswith(endings)),
             None,
         )
 
-    def append(self, attrs: dict[str, str]):
+    def _append(self, attrs: dict[str, str]):
         if (
             attrs["rel"] in ("alternate", "feed")
             and "type" in attrs
-            and attrs["type"].lower() in ACCEPTABLE
+            and attrs["type"].lower() in _ACCEPTABLE
             and "href" in attrs
             and attrs["href"] not in self.added
         ):
             del attrs["rel"]
-            super().append(attrs)
+            super()._append(attrs)
             self.added.add(attrs["href"])
 
 
-def discover_feeds(url: str) -> list:
+def discover_feeds(url: str) -> t.Collection[dict[str, str]]:
     """
     Discover any feeds at the given URL.
+
+    Args:
+        url: URL of page to extract feeds from.
+
+    Returns:
+        The feeds in order of priority. Atom feeds are prioritised first, followed by RDF, and then finally RSS feeds.
     """
-    links, _ = discovery.fetch_meta(url, FeedExtractor)
-    return sorted(links, key=(lambda feed: ORDER[feed["type"]]))
+    links, _ = discovery.fetch_meta(url, _FeedExtractor)
+    return sorted(links, key=(lambda feed: _ORDER[feed["type"]]))

--- a/src/adjunct/discoverfeeds.py
+++ b/src/adjunct/discoverfeeds.py
@@ -35,7 +35,7 @@ class _FeedExtractor(discovery.Extractor):
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]):
         if tag.lower() == "a" and self.anchor is None:
-            fixed_attrs = discovery._fix_attributes(attrs)
+            fixed_attrs = discovery.fix_attributes(attrs)
             if "href" in fixed_attrs:
                 fixed_attrs["@data"] = ""
                 feed_type = self.guess_feed_type(fixed_attrs["href"])

--- a/src/adjunct/discovery.py
+++ b/src/adjunct/discovery.py
@@ -11,7 +11,7 @@ from urllib import parse, request
 
 from .compat import parse_header
 
-__all__ = ["Extractor", "_fix_attributes", "fetch_meta"]
+__all__ = ["Extractor", "fix_attributes", "fetch_meta"]
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class Extractor(HTMLParser):
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         tag = tag.lower()
-        fixed_attrs = _fix_attributes(attrs)
+        fixed_attrs = fix_attributes(attrs)
         if tag == "link":
             self._append(fixed_attrs)
         elif tag == "base" and "href" in fixed_attrs:
@@ -129,9 +129,19 @@ def _safe_slurp(fh: io.IOBase, chunk_size: int = 65536, encoding: str = "UTF-8")
         yield decoded
 
 
-def _fix_attributes(attrs: list[tuple[str, str | None]]) -> dict[str, str]:
-    """
-    Normalise and clean up the attributes, and put them in a dict.
+def fix_attributes(attrs: list[tuple[str, str | None]]) -> dict[str, str]:
+    """Normalise and clean up the attributes, and put them in a dict.
+
+    Attribute names are normalised to lowercase; whitespace within values is
+    trimmed; if the value of an attribute is `None`, it's replaced with an
+    empty string; and the values of the `rel` and `type` attributes are
+    converted to lowercase.
+
+    Args:
+        attrs: raw attributes
+
+    Returns:
+        cleaned-up attributes
     """
     result = {}
     for attr, value in attrs:

--- a/src/adjunct/discovery.py
+++ b/src/adjunct/discovery.py
@@ -11,7 +11,7 @@ from urllib import parse, request
 
 from .compat import parse_header
 
-__all__ = ["Extractor", "fix_attributes", "fetch_meta"]
+__all__ = ["Extractor", "fetch_meta", "fix_attributes"]
 
 logger = logging.getLogger(__name__)
 

--- a/src/adjunct/discovery.py
+++ b/src/adjunct/discovery.py
@@ -11,7 +11,7 @@ from urllib import parse, request
 
 from .compat import parse_header
 
-__all__ = ["Extractor", "fetch_meta", "fix_attributes"]
+__all__ = ["Extractor", "_fix_attributes", "fetch_meta"]
 
 logger = logging.getLogger(__name__)
 
@@ -19,27 +19,37 @@ logger = logging.getLogger(__name__)
 # pylint: disable-msg=R0904
 class Extractor(HTMLParser):
     """
-    A simple subclass of `HTMLParser` for extracting metadata like from <meta>
-    and <link> tags from the header of a HTML document.
+    A simple subclass of `HTMLParser` for extracting metadata like from `<meta>`
+    and `<link>` tags from the header of a HTML document.
+
+    It's recommended you use the `extract` class method.
+
+    Args:
+        base: the base URL for the document
+
+    Attributes:
+        base: the base URL for the document; the `<base>` tag is used if found
+        collected: any collected links; each entry is a dictionary of the attributes
+        properties: any collected `<meta>` tags with `property` and `content` attributes
     """
 
     def __init__(self, base: str) -> None:
         super().__init__()
-        self.base = base
+        self.base: str = base
         self.collected: list[dict[str, str]] = []
         self.properties: list[tuple[str, str]] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         tag = tag.lower()
-        fixed_attrs = fix_attributes(attrs)
+        fixed_attrs = _fix_attributes(attrs)
         if tag == "link":
-            self.append(fixed_attrs)
+            self._append(fixed_attrs)
         elif tag == "base" and "href" in fixed_attrs:
             self.base = parse.urljoin(self.base, fixed_attrs["href"])
         elif tag == "meta" and "property" in fixed_attrs and "content" in fixed_attrs:
             self.properties.append((fixed_attrs["property"], fixed_attrs["content"]))
 
-    def append(self, attrs: dict[str, str]) -> None:
+    def _append(self, attrs: dict[str, str]) -> None:
         """
         Append the given set of attributes onto our list.
 
@@ -47,7 +57,7 @@ class Extractor(HTMLParser):
         """
         self.collected.append(attrs)
 
-    def fix_href(self, href: str) -> str:
+    def _fix_href(self, href: str) -> str:
         """
         Make the given href absolute to any previously discovered <base> tag.
         """
@@ -59,16 +69,21 @@ class Extractor(HTMLParser):
         Extract the link tags from header of a HTML document to be read from
         the file object, `fh`. The return value is a list of dicts where the
         values of each are the attributes of the link elements encountered.
+
+        Args:
+            fh: a file-like object to read the HTML document from.
+            base: A base path/URL to use of URLs in the document. Note that the `<base>` tag will take priority.
+            encoding: default text encoding to assume for the document.
         """
         parser = cls(base)
         with contextlib.closing(parser):
-            for chunk in safe_slurp(fh, encoding=encoding):
+            for chunk in _safe_slurp(fh, encoding=encoding):
                 parser.feed(chunk)
 
         # Canonicalise the URL paths.
         for link in parser.collected:
             if "href" in link:
-                link["href"] = parser.fix_href(link["href"])
+                link["href"] = parser._fix_href(link["href"])
 
         return parser
 
@@ -78,13 +93,23 @@ class Extractor(HTMLParser):
         logger.error("Error in Extractor: %s", message)  # pragma: no cover
 
 
-def safe_slurp(fh: io.IOBase, chunk_size: int = 65536, encoding: str = "UTF-8") -> t.Iterator[str]:
+def _safe_slurp(fh: io.IOBase, chunk_size: int = 65536, encoding: str = "UTF-8") -> t.Iterator[str]:
     """
     Safely convert file object, converting it to the given file encoding.
 
     This handles situations such as UTF-8 characters on chunk boundaries
     gracefully.
+
+    Args:
+        fh: a file-like object to read the data from.
+        chunk_size: what should the approximate maximum size of each chunk be
+        encoding: text encoding to assume for the input data.
     """
+    # Enforce a lower end: 6 will give us 31 bits of codepoint space coverage,
+    # though RFC3629 mandates a max of 4 for compatibility with UTF-16. The
+    # extra leeway shouldn't be a bad thing though. I'm hoping this is fine for
+    # other long encodings too.
+    chunk_size = max(chunk_size, 6)
     prelude = None
     while True:
         chunk = fh.read(chunk_size)
@@ -104,7 +129,7 @@ def safe_slurp(fh: io.IOBase, chunk_size: int = 65536, encoding: str = "UTF-8") 
         yield decoded
 
 
-def fix_attributes(attrs: list[tuple[str, str | None]]) -> dict[str, str]:
+def _fix_attributes(attrs: list[tuple[str, str | None]]) -> dict[str, str]:
     """
     Normalise and clean up the attributes, and put them in a dict.
     """
@@ -122,10 +147,17 @@ def fix_attributes(attrs: list[tuple[str, str | None]]) -> dict[str, str]:
 
 def fetch_meta(
     url: str,
-    extractor=Extractor,
+    extractor: type[Extractor] = Extractor,
 ) -> tuple[t.Collection[dict[str, str]], t.Collection[tuple[str, str]]]:
     """
     Extract the <link> tags from the HTML document at the given URL.
+
+    As this is fetching the document over HTTP, it can also support the
+    [Link header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Link).
+
+    Args:
+        url: URL of the document to extract the link tags from.
+        extractor: an Extractor subclass
     """
     links = []
     properties = []

--- a/src/adjunct/gravatar.py
+++ b/src/adjunct/gravatar.py
@@ -1,5 +1,7 @@
 """
 Gravatar support.
+
+For information on the parameters, see [the SDK](https://docs.gravatar.com/sdk/images/).
 """
 
 import hashlib
@@ -12,8 +14,16 @@ def make_gravatar_img(
     default: str = "identicon",
     rating: str = "pg",
 ) -> str:
-    """
-    Generate a Gravatar <img> tag for the given email address.
+    """Generate a Gravatar `<img>` tag for the given email address.
+
+    Args:
+        email: an email address
+        size: the size of the gravatar to generate
+        default: default image to generate
+        rating: the rating associated with the image
+
+    Returns:
+        An `<img>` tag with suitable attributes.
     """
     url = make_gravatar(email, size, default, rating)
     return f'<img src="{url}" width="{size}" height="{size}" alt="">'
@@ -25,11 +35,16 @@ def make_gravatar(
     default: str = "identicon",
     rating: str = "pg",
 ) -> str:
-    """
-    Generate a gravatar image URL.
+    """Generate a gravatar image URL.
 
-    For information on the parameters, see:
-    <https://en.gravatar.com/site/implement/images/>
+    Args:
+        email: an email address
+        size: the size of the gravatar to generate
+        default: default image to generate
+        rating: the rating associated with the image
+
+    Returns:
+        A Gravatar URL.
     """
     params = {
         "s": str(size),

--- a/src/adjunct/html.py
+++ b/src/adjunct/html.py
@@ -126,7 +126,7 @@ class Element:
 
 class _Parser(HTMLParser):
     """
-    Parses a HTML document into an [_Element][].
+    Parses a HTML document into an [Element][].
     """
 
     def __init__(self) -> None:

--- a/src/adjunct/html.py
+++ b/src/adjunct/html.py
@@ -13,12 +13,12 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "Element",
-    "Parser",
+    "_Parser",
     "escape",
 ]
 
 # See: https://html.spec.whatwg.org/multipage/syntax.html#void-elements
-SELF_CLOSING = {
+_SELF_CLOSING = {
     "area",
     "base",
     "br",
@@ -46,6 +46,15 @@ def make(
 ) -> str:
     """
     Helper for quickly constructing a HTML tag.
+
+    Args:
+        tag: tag name
+        attrs: attributes to apply to the tag
+        close: set to `True` or `False` to determine whether a closing tag
+            should be generated; omit to let the function decide
+
+    Returns:
+        the tag
     """
     attr_list = []
     for name, value in attrs.items():
@@ -55,7 +64,7 @@ def make(
             attr_list.append(f' {name}="{escape(value, quote=True)}"')
     result = f"<{tag}{''.join(attr_list)}>"
     if close is None:
-        close = tag not in SELF_CLOSING
+        close = tag not in _SELF_CLOSING
     if close:
         result += f"</{tag}>"
     return result
@@ -63,6 +72,15 @@ def make(
 
 @dataclasses.dataclass
 class Element:
+    """
+    A HTML element.
+
+    Attributes:
+        tag: the tag name
+        attrs: the tag's attributes
+        children: the child elements of the element
+    """
+
     tag: str | None
     attrs: dict = dataclasses.field(default_factory=dict)
     children: list = dataclasses.field(default_factory=list)
@@ -77,6 +95,15 @@ class Element:
         return iter(self.children)
 
     def serialize(self, dest: io.TextIOBase | None = None) -> io.TextIOBase:
+        """Serialise the element to a file-like object.
+
+        Args:
+            dest: the file-like object to serialise the document to; if this is
+                `None`, as [io.StringIO][] object will be created instead.
+
+        Returns:
+            A file-like object containing the serialised element.
+        """
         if dest is None:
             dest = io.StringIO()
         if self.tag is not None:
@@ -91,15 +118,15 @@ class Element:
                 dest.write(escape(child, quote=False))
             elif isinstance(child, Element):
                 child.serialize(dest)
-        if self.tag is not None and self.tag not in SELF_CLOSING:
+        if self.tag is not None and self.tag not in _SELF_CLOSING:
             dest.write(f"</{self.tag}>")
 
         return dest
 
 
-class Parser(HTMLParser):
+class _Parser(HTMLParser):
     """
-    Parses a HTML document into
+    Parses a HTML document into an [_Element][].
     """
 
     def __init__(self) -> None:
@@ -114,7 +141,7 @@ class Parser(HTMLParser):
     def handle_starttag(self, tag, attrs) -> None:
         elem = Element(tag=tag, attrs=dict(attrs))
         self.top.children.append(elem)
-        if tag not in SELF_CLOSING:
+        if tag not in _SELF_CLOSING:
             self.stack.append(elem)
 
     def handle_startendtag(self, tag, attrs) -> None:
@@ -122,7 +149,7 @@ class Parser(HTMLParser):
         self.top.children.append(elem)
 
     def handle_endtag(self, tag) -> None:
-        if tag not in SELF_CLOSING:
+        if tag not in _SELF_CLOSING:
             while len(self.stack) > 1:
                 self.stack.pop()
                 if tag == self.top.tag:
@@ -139,7 +166,15 @@ class Parser(HTMLParser):
 
 
 def parse(markup: str) -> Element:
-    parser = Parser()
+    """Parse a HTML document, returning its root element.
+
+    Args:
+        markup: the document to parse
+
+    Returns:
+        The root element of the document.
+    """
+    parser = _Parser()
     parser.feed(markup)
     parser.close()
     return parser.root

--- a/src/adjunct/netstrings.py
+++ b/src/adjunct/netstrings.py
@@ -33,7 +33,7 @@ def netstring_reader(fd: io.BufferedIOBase) -> t.Iterable[bytes]:  # noqa: C901
     Reads a sequence of netstrings from the given file object.
 
     Args:
-        fd: a file-lke object to read from
+        fd: a file-like object to read from
 
     Yields:
         netstrings

--- a/src/adjunct/netstrings.py
+++ b/src/adjunct/netstrings.py
@@ -17,6 +17,12 @@ class MalformedNetstringError(Exception):
 def parse(ns: bytes) -> t.Sequence[bytes]:
     """
     Parse a bytestring of netstrings.
+
+    Args:
+        ns: the netstrings to parse; there may be multiple in the input buffer
+
+    Returns:
+        All the netstrings found in the input buffer
     """
     with io.BytesIO(ns) as fh:
         return list(netstring_reader(fh))
@@ -25,6 +31,12 @@ def parse(ns: bytes) -> t.Sequence[bytes]:
 def netstring_reader(fd: io.BufferedIOBase) -> t.Iterable[bytes]:  # noqa: C901
     """
     Reads a sequence of netstrings from the given file object.
+
+    Args:
+        fd: a file-lke object to read from
+
+    Yields:
+        netstrings
     """
     while True:
         buffered = b""

--- a/src/adjunct/ogp.py
+++ b/src/adjunct/ogp.py
@@ -46,6 +46,7 @@ class Property:
 
 
 def parse(properties: t.Collection[tuple[str, str]]) -> t.Sequence[Property]:
+    """"""
     result = []
     for name, value in properties:
         name_parts = name.split(":", 2)
@@ -60,6 +61,7 @@ def parse(properties: t.Collection[tuple[str, str]]) -> t.Sequence[Property]:
 
 
 def to_meta(props: Property | t.Sequence[Property]) -> str:
+    """"""
     if isinstance(props, Property):
         return props.to_meta()
     return "\n".join(prop.to_meta() for prop in props)
@@ -70,6 +72,7 @@ def find(
     type_: str,
     value: str | None = None,
 ) -> t.Iterable[Property]:
+    """"""
     for prop in props:
         if prop.type_ == type_ and (value is None or prop.value == value):
             yield prop

--- a/src/adjunct/passkit.py
+++ b/src/adjunct/passkit.py
@@ -18,32 +18,32 @@ class UnknownAlgorithmError(Exception):
     """Raised when an entry has either an unknown algorithm or none."""
 
 
-class ScryptParams(t.TypedDict):
+class _ScryptParams(t.TypedDict):
     n: int
     r: int
     p: int
 
 
-class ScryptEntry(t.TypedDict):
+class _ScryptEntry(t.TypedDict):
     alg: t.Literal["scrypt"]
     key: str
     salt: str
-    params: ScryptParams
+    params: _ScryptParams
 
 
-def scrypt_construct(passwd: bytes, *, salt_len: int = 32, n: int = 1 << 14, r: int = 8, p: int = 1) -> ScryptEntry:
+def _scrypt_construct(passwd: bytes, *, salt_len: int = 32, n: int = 1 << 14, r: int = 8, p: int = 1) -> _ScryptEntry:
     """Construct an entry from a password using scrypt."""
     salt = secrets.token_bytes(salt_len)
     key = hashlib.scrypt(passwd, salt=salt, n=n, r=r, p=p)
-    return ScryptEntry(
+    return _ScryptEntry(
         alg="scrypt",
         key=base64.b64encode(key).decode("ascii"),
         salt=base64.b64encode(salt).decode("ascii"),
-        params=ScryptParams(n=n, r=r, p=p),
+        params=_ScryptParams(n=n, r=r, p=p),
     )
 
 
-def scrypt_check(passwd: bytes, entry: ScryptEntry) -> bool:
+def _scrypt_check(passwd: bytes, entry: _ScryptEntry) -> bool:
     """Check if a password matches the given entry using scrypt."""
     key = hashlib.scrypt(
         passwd,
@@ -105,9 +105,9 @@ class JSONPasswdFile:
     # product.
     _implementations: t.ClassVar = {
         "scrypt": {
-            "entry": ScryptEntry,
-            "construct": scrypt_construct,
-            "check": scrypt_check,
+            "entry": _ScryptEntry,
+            "construct": _scrypt_construct,
+            "check": _scrypt_check,
         }
     }
 
@@ -141,10 +141,12 @@ class JSONPasswdFile:
             json.dump(payload, fh)
 
     def set_password(self, username: str, password: str):
+        """"""
         self.users[username] = self._implementations[self.implementation]["construct"](password.encode("utf-8"))
         self._save()
 
     def check_password(self, username: str, password: str) -> bool:
+        """"""
         entry = self.users.get(username)
         if entry is None:
             return False
@@ -157,6 +159,7 @@ class JSONPasswdFile:
         return impl["check"](password.encode("utf-8"), entry)
 
     def delete(self, username) -> bool:
+        """"""
         if username in self.users:
             del self.users[username]
             self._save()

--- a/src/adjunct/totp.py
+++ b/src/adjunct/totp.py
@@ -7,13 +7,13 @@ import urllib.parse as _parse
 
 
 class UnknownHashAlgorithmError(Exception):
-    """Raised if the named hash algorithm was not recognised."""
+    """Raised if the named hash algorithm was not recognised.
+
+    Args:
+        alg: Hash algorithm name given
+    """
 
     def __init__(self, alg: str):
-        """
-        Args:
-            alg: Hash algorithm name given
-        """
         self.alg = alg
         message = f"'{alg}' is not a supported TOTP hash algorithm"
         super().__init__(message)
@@ -26,7 +26,20 @@ _unpack_uint32 = struct.Struct(">I").unpack
 
 
 class TOTP:
-    """An implementation of TOTP (RFC 6238)."""
+    """An implementation of TOTP (RFC 6238).
+
+    Args:
+        key: A buffer of random bytes acting as a key. Will be generated if None.
+        alg: Hash algorithm to use for the OTP. Defaults to "sha1", but supports sha256 and sha512.
+        digits: Length of the OTP. Defaults to 6 digits.
+        period: Validity period in seconds of the OTP. Defaults to 30.
+        key_size: If no key is given, the length in bytes of the key go generate. Default to 16.
+
+    Raises:
+        UnknownHashAlgorithmError: If the hash algorithm given is not recognised.
+    """
+
+    __slots__ = ["alg", "digits", "key", "period"]
 
     def __init__(
         self,
@@ -37,17 +50,6 @@ class TOTP:
         period: int = 30,
         key_size: int = 16,
     ) -> None:
-        """
-        Args:
-            key: A buffer of random bytes acting as a key. Will be generated if None.
-            alg: Hash algorithm to use for the OTP. Defaults to "sha1", but supports sha256 and sha512.
-            digits: Length of the OTP. Defaults to 6 digits.
-            period: Validity period in seconds of the OTP. Defaults to 30.
-            key_size: If no key is given, the length in bytes of the key go generate. Default to 16.
-
-        Raises:
-            UnknownHashAlgorithmError: If the hash algorithm given is not recognised.
-        """
         if alg not in _allowed_hashes:
             raise UnknownHashAlgorithmError(alg)
         if key is None:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -73,12 +73,12 @@ def test_fetch_meta():
 def test_safe_slurp():
     data = b"Hello, world!\nThis is a test.\n"
     fh = io.BytesIO(data)
-    result = "".join(discovery.safe_slurp(fh, chunk_size=4, encoding="utf-8"))
+    result = "".join(discovery._safe_slurp(fh, chunk_size=4, encoding="utf-8"))
     assert result == data.decode("utf-8")
 
 
 def test_fix_attributes():
-    assert discovery.fix_attributes(
+    assert discovery._fix_attributes(
         [
             ("REL", " Foo "),
             ("data-value", None),

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -78,7 +78,7 @@ def test_safe_slurp():
 
 
 def test_fix_attributes():
-    assert discovery._fix_attributes(
+    assert discovery.fix_attributes(
         [
             ("REL", " Foo "),
             ("data-value", None),

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -77,6 +77,17 @@ def test_safe_slurp():
     assert result == data.decode("utf-8")
 
 
+def test_safe_slurp_multibyte_utf8_across_chunks():
+    # Use multi-byte UTF-8 characters (emoji and accented characters)
+    text = "Hello \N{EARTH GLOBE EUROPE-AFRICA} \N{EN DASH} café \N{SMILING FACE WITH SMILING EYES}"
+    data = text.encode("utf-8")
+
+    # Use a chunk size smaller than some characters' byte length to force splits
+    fh = io.BytesIO(data)
+    result = "".join(discovery._safe_slurp(fh, chunk_size=2, encoding="utf-8"))
+    assert result == text
+
+
 def test_fix_attributes():
     assert discovery.fix_attributes(
         [

--- a/tests/test_fixtureutils.py
+++ b/tests/test_fixtureutils.py
@@ -11,7 +11,7 @@ def test_make_fake_http_response_msg():
     msg = fixtureutils.make_fake_http_response_msg(
         code=404,
         body="Not Found",
-        headers={"Content-Type": "text/plain"},
+        headers=[("Content-Type", "text/plain")],
     )
     assert msg == b"HTTP/1.0 404 Not Found\r\nContent-Length: 9\nContent-Type: text/plain\n\nNot Found"
 
@@ -20,7 +20,7 @@ def test_make_fake_http_response_msg_complex_header():
     msg = fixtureutils.make_fake_http_response_msg(
         code=404,
         body="Not Found",
-        headers={"Content-Type": ("text/plain", {"charset": "UTF-8"})},
+        headers=[("Content-Type", ("text/plain", {"charset": "UTF-8"}))],
     )
     assert msg == b'HTTP/1.0 404 Not Found\r\nContent-Length: 9\nContent-Type: text/plain; charset="UTF-8"\n\nNot Found'
 
@@ -37,10 +37,10 @@ def test_make_fake_http_response():
     response = fixtureutils.make_fake_http_response(
         body="Hello, World!",
         code=200,
-        headers={
-            "Content-Type": "text/plain",
-            "X-Custom-Header": "CustomValue",
-        },
+        headers=[
+            ("Content-Type", "text/plain"),
+            ("X-Custom-Header", "CustomValue"),
+        ],
     )
     assert response.status == 200
     assert response.getheader("Content-Type") == "text/plain"
@@ -59,20 +59,17 @@ def test_json_response():
 
     result = fixtureutils.json_response(start_response, {"key": "value"})
 
+    assert b"".join(result) == b'{"key": "value"}'
     assert response_status.startswith("200")
     headers_dict = dict(response_headers)
     assert headers_dict["Content-Type"] == "application/json; charset=UTF-8"
-    assert b"".join(result) == b'{"key": "value"}'
 
 
 def fixture_app(environ, start_response):  # noqa: ARG001
     """
     A simple WSGI application for testing purposes.
     """
-    status = "200 OK"
-    headers = [("Content-Type", "text/plain; charset=UTF-8")]
-    start_response(status, headers)
-    return [b"Fixture App Response"]
+    return fixtureutils.basic_response(start_response, 200, "Fixture App Response")
 
 
 def test_fixture():

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -84,6 +84,13 @@ class TestElement(unittest.TestCase):
         )
 
 
+def test_no_file_object_serialiser():
+    expected = "<br>"
+    fo = html.parse(expected).serialize()
+    assert isinstance(fo, io.StringIO)
+    assert fo.getvalue() == expected
+
+
 def test_make_html():
     assert html.make("br", attrs={}) == "<br>"
     assert html.make("a", attrs={"href": "foo"}) == '<a href="foo"></a>'

--- a/tests/test_oembed.py
+++ b/tests/test_oembed.py
@@ -130,7 +130,7 @@ class OEmbedXMLParserTest(unittest.TestCase):
 def make_response(dct, content_type="application/json+oembed; charset=UTF-8"):
     return make_fake_http_response(
         body=json.dumps(dct),
-        headers={"Content-Type": content_type},
+        headers=[("Content-Type", content_type)],
     )
 
 
@@ -165,13 +165,13 @@ class FetchTest(unittest.TestCase):
 def app_400(environ, start_response):  # noqa: ARG001
     headers = [("Content-Type", "text/plain; charset=utf-8")]
     start_response("400 Bad Request", headers)
-    return [b"Bad request"]
+    yield b"Bad request"
 
 
 def app_500(environ, start_response):  # noqa: ARG001
     headers = [("Content-Type", "text/plain; charset=utf-8")]
     start_response("500 Internal Server Error", headers)
-    return [b"Internal server error"]
+    yield b"Internal server error"
 
 
 def test_fetch_oembed_with_error():


### PR DESCRIPTION
Additionally, I've hidden a bunch of stuff that doesn't need to be exposed, simplified the type of `make_fake_http_response_msg`, and added a heap of type annotations.

## Summary by Sourcery

Improve library documentation and typing while tightening public APIs and refining HTTP/WSGI and discovery utilities.

New Features:
- Add a just task to run the MkDocs development server for the documentation site.

Bug Fixes:
- Ensure WSGI response helpers return/generate proper iterable bodies instead of plain lists in fixtures and test apps.
- Make netstring parsing and safe text slurping more robust when dealing with chunked or boundary-encoded data.

Enhancements:
- Add comprehensive docstrings and type annotations across HTTP fixtures, discovery, HTML, Gravatar, TOTP, OEmbed, feed discovery, and Open Graph utilities.
- Restrict and clarify public APIs by prefixing internal helpers with underscores and tightening __all__ exports.
- Simplify and standardize HTTP helper interfaces, including fake HTTP response construction and header handling.
- Optimize feed and metadata discovery helpers and oEmbed parsing by using typed collections and internal helpers.
- Add __slots__ to the TOTP class to reduce attribute overhead and clarify its constructor semantics.

Build:
- Update MkDocs configuration to watch source and docs directories for live reload during documentation development.

Documentation:
- Polish existing TOTP documentation formatting and expand auto-generated API docs through richer docstrings.

Tests:
- Update and extend tests for fixtures, discovery, and oEmbed helpers to match the new response semantics and header interfaces.