### PR TITLE
Publish docs and upgrade ruff and uv in the pipelines

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - mkdocs.yml
       - "docs/**"
+      - "src/adjunct/**"
 
 permissions:
   contents: write
@@ -19,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          persist-credentials: false
+          persist-credentials: true
       - uses: astral-sh/setup-uv@v6
         with:
           version: "0.9.5"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+---
+name: Publish documentation
+
+on:
+  workflow_dispatch: {}
+  push:
+    tags:
+      - "v*"
+    paths:
+      - mkdocs.yml
+      - "docs/**"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.9.5"
+          python-version: "3.11"
+      - name: Deploy site
+        run: uv run mkdocs gh-deploy --force

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: astral-sh/ruff-action@v3
         with:
-          version: "0.11.13"
+          version: "0.14.3"
 
   test:
     runs-on: ubuntu-latest
@@ -32,10 +34,12 @@ jobs:
           - "3.14"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@v6
         with:
-          version: "0.7.13"
+          version: "0.9.5"
           python-version: ${{ matrix.python-version }}
       - name: Run tests
         run: uv run --frozen pytest


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflows to use newer tooling versions and add automated documentation publishing.

Build:
- Bump GitHub Actions checkout to v5 and configure it to avoid persisting credentials in test and lint workflows.
- Upgrade ruff and uv versions used in CI pipelines to more recent releases.
- Add a dedicated workflow to build and publish MkDocs documentation on tagged releases and manual dispatch.