### PR TITLE
I was a bit hasty in hiding get_oembed

### DIFF
--- a/src/adjunct/oembed.py
+++ b/src/adjunct/oembed.py
@@ -11,7 +11,7 @@ import xml.sax.handler
 
 from .compat import parse_header
 
-__all__ = ["fetch"]
+__all__ = ["fetch", "get_oembed"]
 
 
 class _OEmbedContentHandler(xml.sax.handler.ContentHandler):
@@ -36,10 +36,10 @@ class _OEmbedContentHandler(xml.sax.handler.ContentHandler):
 
     def __init__(self) -> None:
         super().__init__()
-        self.current_field = None
-        self.current_value = []
+        self.current_field: str | None = None
+        self.current_value: list[str] = []
         self.depth = 0
-        self.fields = {}
+        self.fields: dict[str, str | int] = {}
 
     def startElement(self, name, attrs) -> None:  # noqa: N802, ARG002
         self.depth += 1
@@ -147,7 +147,7 @@ def _find_first_oembed_link(links: t.Collection[dict[str, str]]) -> str | None:
     return None
 
 
-def _get_oembed(
+def get_oembed(
     links: t.Collection[dict[str, str]],
     max_width: int | None = None,
     max_height: int | None = None,

--- a/tests/test_oembed.py
+++ b/tests/test_oembed.py
@@ -11,9 +11,9 @@ from adjunct.fixtureutils import make_fake_http_response
 from adjunct.oembed import (
     _build_url,
     _find_first_oembed_link,
-    _get_oembed,
     _parse_xml_oembed_response,
     fetch,
+    get_oembed,
 )
 
 
@@ -80,7 +80,7 @@ class OEmbedFinderTest(unittest.TestCase):
         self.assertEqual(result, "http://www.example.com/oembed?format=xml")
 
     def test_get_oembed_none(self):
-        result = _get_oembed(LINKS_WITHOUT)
+        result = get_oembed(LINKS_WITHOUT)
         self.assertIsNone(result)
 
     @mock.patch("urllib.request.urlopen")
@@ -95,7 +95,7 @@ class OEmbedFinderTest(unittest.TestCase):
             "title": "A video",
         }
         mock_urlopen.return_value = make_response(doc)
-        result = _get_oembed([*LINKS_WITHOUT, *LINKS_WITH])
+        result = get_oembed([*LINKS_WITHOUT, *LINKS_WITH])
         assert result is not None
         self.assertDictEqual(result, doc)
 


### PR DESCRIPTION
I'm also adding some extra type annotations after mypy complained.

## Summary by Sourcery

Restore and expose the oEmbed retrieval helper while tightening type annotations in the oEmbed module.

New Features:
- Re-expose the get_oembed helper as part of the public oEmbed API.

Enhancements:
- Add concrete type annotations to the oEmbed XML content handler internals for improved static checking.

Tests:
- Update oEmbed tests to call the now-public get_oembed helper instead of the internal variant.