### PR TITLE
Fix some documentation nits

### DIFF
--- a/src/adjunct/discoverfeeds.py
+++ b/src/adjunct/discoverfeeds.py
@@ -88,7 +88,8 @@ def discover_feeds(url: str) -> t.Collection[dict[str, str]]:
         url: URL of page to extract feeds from.
 
     Returns:
-        The feeds in order of priority. Atom feeds are prioritised first, followed by RDF, and then finally RSS feeds.
+        The feeds in order of priority. Atom feeds are prioritised first,
+            followed by RDF, and then finally RSS feeds.
     """
     links, _ = discovery.fetch_meta(url, _FeedExtractor)
     return sorted(links, key=(lambda feed: _ORDER[feed["type"]]))

--- a/src/adjunct/oembed.py
+++ b/src/adjunct/oembed.py
@@ -83,8 +83,8 @@ def fetch(
 
     Returns:
         An oEmbed document as a dictionary; `None` if the document could not
-        be fetched or the content type of the response was not valid for an
-        oEmbed document.
+            be fetched or the content type of the response was not valid for an
+            oEmbed document.
     """
     headers = {
         "Accept": ", ".join(_ACCEPTABLE_TYPES.keys()),
@@ -137,7 +137,7 @@ def _find_first_oembed_link(links: t.Collection[dict[str, str]]) -> str | None:
 
     Returns:
         The value of the `href` attribute of the first one with a valid oEmbed
-        MIME type specified in its `type` attribute.
+            MIME type specified in its `type` attribute.
     """
     for link in links:
         if link.get("rel") == "alternate" and link.get("type") in _LINK_TYPES:
@@ -161,8 +161,8 @@ def get_oembed(
 
     Returns:
         An oEmbed document as a dictionary; `None` if the document could not
-        be fetched or the content type of the response was not valid for an
-        oEmbed document.
+            be fetched or the content type of the response was not valid for an
+            oEmbed document.
     """
     if oembed_url := _find_first_oembed_link(links):
         return fetch(oembed_url, max_width, max_height)

--- a/src/adjunct/pagination.py
+++ b/src/adjunct/pagination.py
@@ -1,6 +1,4 @@
-"""
-Pagination support code.
-"""
+"""Pagination support."""
 
 import typing as t
 

--- a/src/adjunct/passkit.py
+++ b/src/adjunct/passkit.py
@@ -1,6 +1,5 @@
 """A partial replacement for [passlib].
 
-
 Iimplementing an equivalent of its HtpasswdFile class and supporting
 functionality.
 

--- a/src/adjunct/passkit.py
+++ b/src/adjunct/passkit.py
@@ -1,6 +1,6 @@
 """A partial replacement for [passlib].
 
-Iimplementing an equivalent of its HtpasswdFile class and supporting
+Implementing an equivalent of its HtpasswdFile class and supporting
 functionality.
 
 It comes with a simple tool for manipulating JSONPasswd files.


### PR DESCRIPTION
Mainly, there are a few places where I didn't realise the Google-style docstrings require continuations to be indented.

## Summary by Sourcery

Tighten up documentation formatting for oEmbed utilities and feed discovery helpers to comply with Google-style docstring conventions.

Documentation:
- Fix docstring indentation to follow Google-style continuation formatting in oEmbed and feed discovery modules.
- Clean up module-level documentation in the passkit module.