### PR TITLE
Get rid of time.date

### DIFF
--- a/src/adjunct/time.py
+++ b/src/adjunct/time.py
@@ -3,59 +3,33 @@
 import datetime
 
 
-def date(
-    dt: str,
-    fmt: str = "%Y-%m-%dT%H:%M:%S%z",
-    tz: datetime.timezone = datetime.UTC,
-):
-    """Format an SQLite timestamp.
-
-    SQLite timestamps are taken to be in UTC. If you want them adjusted to
-    another timezone, pass a `tzinfo` object representing that timezone in
-    the `tz` parameter. The `fmt` parameter specifies a `strftime` date format
-    string; it defaults to the [ISO 8601]/[RFC 3339] date format.
-
-    [ISO 8601]: http://en.wikipedia.org/wiki/ISO_8601
-    [RFC 3339]: http://tools.ietf.org/html/rfc3339
-
-    Args:
-        dt: an SQLite timestamp string
-        fmt: a [datetime.datetime.strftime][] date format string
-        tz: a timezone object
-
-    Returns:
-        The formatted time
-    """
-    return parse_dt(dt, tz).strftime(fmt)
-
-
 def parse_dt(
     dt: str,
     tz: datetime.timezone | None = datetime.UTC,
 ) -> datetime.datetime:
-    """Parse an SQLite datetime, treating it as UTC.
+    """Parse an SQLite datetime, treating it as UTC by default.
 
     Args:
         dt: an SQLite timestamp string
         tz: the timezone to use, or `None` to treat it naively
 
     Returns:
-        the parsed datetime
+        the parsed datetime.
     """
     parsed = datetime.datetime.strptime(dt, "%Y-%m-%d %H:%M:%S")  # noqa: DTZ007
     return parsed if tz is None else parsed.replace(tzinfo=tz)
 
 
-def to_iso_date(dt: str) -> str:
+def to_iso_date(dt: str, tz: datetime.timezone = datetime.UTC) -> str:
     """Convert an SQLite timestamp string to [ISO 8601] format.
 
     [ISO 8601]: http://en.wikipedia.org/wiki/ISO_8601
 
     Args:
         dt: an SQLite timestamp string
+        tz: a timezone object
 
     Returns:
         the same timestamp, but in ISO 8601 format.
-
     """
-    return parse_dt(dt).isoformat()
+    return parse_dt(dt, tz).isoformat()

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,19 +1,21 @@
 import datetime
-import unittest
 
 from adjunct import time
 
 
-class TimeTest(unittest.TestCase):
-    def test_date(self):
-        self.assertEqual(
-            time.date("2033-05-18 03:33:20"),
-            "2033-05-18T03:33:20+0000",
-        )
+def test_parse_dt():
+    expected = datetime.datetime(
+        year=2033,
+        month=5,
+        day=18,
+        hour=3,
+        minute=33,
+        second=20,
+        tzinfo=datetime.UTC,
+    )
+    assert time.parse_dt("2033-05-18 03:33:20") == expected
 
-    def test_tz(self):
-        ist = datetime.timezone(datetime.timedelta(hours=-1), "IST")
-        self.assertEqual(
-            time.date("2033-05-18 03:33:20", tz=ist),
-            "2033-05-18T03:33:20-0100",
-        )
+
+def test_tz():
+    ist = datetime.timezone(datetime.timedelta(hours=-1), "IST")
+    assert time.to_iso_date("2033-05-18 03:33:20", tz=ist) == "2033-05-18T03:33:20-01:00"


### PR DESCRIPTION
It's not actually used and it's a hangover from years ago that hung around for ages.

## Summary by Sourcery

Remove the obsolete SQLite timestamp formatting helper and align time utilities and tests around timezone-aware parsing and ISO formatting.

Enhancements:
- Allow to_iso_date to accept an explicit timezone parameter while keeping UTC as the default.
- Refine parse_dt documentation to clarify its default UTC behavior.

Tests:
- Replace class-based unittest tests for the old date helper with pytest-style tests covering parse_dt and to_iso_date, including timezone handling.

Chores:
- Delete the unused date helper function from the time utilities module.