### PR TITLE
Fix naming of testing target

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ tidy:
 	@uv run --frozen ruff check --fix
 
 # run the test suite
-tests:
+test:
 	@uv run --frozen pytest
 
 # run the typechecker


### PR DESCRIPTION
## Summary by Sourcery

Rename the test-suite justfile recipe to use the singular `test` target name for running pytest.

Bug Fixes:
- Correct the naming of the justfile target used to run the test suite.

Build:
- Align the justfile test target name with the expected `test` command.