### PR TITLE
slog: structured logging build on Python's built-in logging module

### DIFF
--- a/docs/adjunct.slog.md
+++ b/docs/adjunct.slog.md
@@ -1,0 +1,6 @@
+# adjunct.slog
+
+::: adjunct.slog
+    options:
+      show_root_heading: false
+      show_source: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - adjunct.pagination.md
       - adjunct.passkit.md
       - adjunct.singleton.md
+      - adjunct.slog.md
       - adjunct.time.md
       - adjunct.totp.md
       - adjunct.xmlutils.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ ban-relative-imports = "all"
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["ANN", "PLR2004", "S101", "TID252", "E501"]
+"tests/**/*" = ["ANN", "PLR2004", "S101", "TID252", "E501", "T201", "E722"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/src/adjunct/slog.py
+++ b/src/adjunct/slog.py
@@ -1,0 +1,124 @@
+"""Simple structured logging with spans.
+
+This module provides utilities for structured logging in JSON format, including
+the ability to create logging spans that carry contextual metadata.
+
+It builds on Python's built-in [logging][] module.
+"""
+
+import base64
+import json
+import logging
+import os
+import threading
+
+
+def _generate_span_id():
+    return base64.b16encode(os.urandom(8)).decode("utf-8")
+
+
+class _SpanStack(threading.local):
+    """A thread-local stack of logging spans."""
+
+    def __init__(self):
+        super().__init__()
+        self._stack: list[dict[str, str]] = [{"spanId": _generate_span_id()}]
+
+    def top(self) -> dict[str, str]:
+        return self._stack[-1]
+
+    def extend(self, **kwargs: str) -> None:
+        """Add additional context to the current span."""
+        self._stack[-1].update(kwargs)
+
+    def __enter__(self) -> "_SpanStack":
+        return self
+
+    def __exit__(self, *_) -> None:
+        self._stack.pop()
+
+    def __call__(self, /, **kwargs) -> "_SpanStack":
+        top = self._stack[-1]
+        ctx = {**top, **kwargs, "spanId": _generate_span_id(), "parentSpanId": top["spanId"]}
+        self._stack.append(ctx)
+        return self
+
+
+span = _SpanStack()
+"""A context manager for logging spans.
+
+Examples:
+    >>> with slog.span(request_id="12345", user_id="alice"):
+    ...    logger.info(slog.M("User action", action="update_profile"))
+"""
+
+
+class M:
+    """A message with some attached metaadata for structured logging.
+
+    When stringified, this produces a JSON-like string that can be parsed by log processors.
+
+    If used with JSONFormatter, it'll merge the metadata into the log record.
+
+    Args:
+        message: The main log message.
+        **metadata: Additional key-value pairs to attach to the log record.
+    """
+
+    __slots__ = ("message", "metadata")
+
+    def __init__(self, message: str, **metadata: str) -> None:
+        self.message = message
+        self.metadata = metadata
+
+    def __str__(self) -> str:
+        if not self.metadata:
+            return self.message
+        ctx = span.top()
+        combined = {**ctx, **self.metadata}
+        return f"{self.message} | {json.dumps(combined)}"
+
+
+class JSONFormatter(logging.Formatter):
+    """A logging formatter that outputs JSON log records."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        record_dict: dict[str, str | dict[str, str]] = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            **span.top(),
+        }
+        if isinstance(record.msg, M):
+            record_dict.update(record.msg.metadata)
+            record_dict["message"] = record.msg.message
+        else:
+            record_dict["message"] = record.getMessage()
+        if record.exc_info:
+            record_dict["exception"] = self.formatException(record.exc_info)
+        return json.dumps(record_dict)
+
+
+def get_logger(
+    name: str,
+    level: int = logging.INFO,
+    handler: logging.Handler | None = None,
+) -> logging.Logger:
+    """Get a structured logger with JSON formatting.
+
+    Args:
+        name: The name of the logger.
+        level: The logging level.
+        handler: An optional logging handler. If not provided, a StreamHandler is used.
+
+    Returns:
+        A configured logging.Logger instance.
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    if handler is None:  # pragma: no cover
+        handler = logging.StreamHandler()
+    handler.setFormatter(JSONFormatter())
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger

--- a/tests/tests/test_slog.py
+++ b/tests/tests/test_slog.py
@@ -1,0 +1,104 @@
+import io
+import json
+import logging
+
+from adjunct import slog
+
+
+def test_structured_message_logging():
+    stream = io.StringIO()
+    logger = slog.get_logger("test_logger", level=logging.DEBUG, handler=logging.StreamHandler(stream))
+
+    logger.info(slog.M("Test message", user="alice", action="login"))
+
+    log_output = stream.getvalue().strip()
+    log_record = json.loads(log_output)
+
+    assert log_record["message"] == "Test message"
+    assert log_record["user"] == "alice"
+    assert log_record["action"] == "login"
+    assert "spanId" in log_record
+
+
+def test_span_metadata_in_logging():
+    stream = io.StringIO()
+    logger = slog.get_logger("test_logger", level=logging.DEBUG, handler=logging.StreamHandler(stream))
+
+    with slog.span(request_id="12345", user_id="alice"):
+        logger.info(slog.M("User action", action="update_profile"))
+
+    log_output = stream.getvalue().strip()
+    log_record = json.loads(log_output)
+
+    assert log_record["message"] == "User action"
+    assert log_record["action"] == "update_profile"
+    assert log_record["request_id"] == "12345"
+    assert log_record["user_id"] == "alice"
+
+
+def test_nested_spans_logging():
+    stream = io.StringIO()
+    logger = slog.get_logger("test_logger", level=logging.DEBUG, handler=logging.StreamHandler(stream))
+
+    with slog.span(request_id="12345"):
+        logger.info(slog.M("Outer span message"))
+        with slog.span(user_id="alice"):
+            logger.info(slog.M("Nested span message", action="delete_account"))
+
+    log_output = stream.getvalue().strip()
+    log_lines = log_output.splitlines()
+    outer_log_record = json.loads(log_lines[0])
+    nested_log_record = json.loads(log_lines[1])
+
+    assert outer_log_record["message"] == "Outer span message"
+    assert outer_log_record["request_id"] == "12345"
+    assert "user_id" not in outer_log_record
+
+    assert nested_log_record["message"] == "Nested span message"
+    assert nested_log_record["request_id"] == "12345"
+    assert nested_log_record["user_id"] == "alice"
+    assert nested_log_record["action"] == "delete_account"
+
+    assert outer_log_record["spanId"] != nested_log_record["spanId"]
+
+
+def test_exception_logging():
+    stream = io.StringIO()
+    logger = slog.get_logger("test_logger", level=logging.DEBUG, handler=logging.StreamHandler(stream))
+
+    try:
+        raise KeyError("Test exception")
+    except:
+        logger.exception("Something went wrong")
+
+    log_output = stream.getvalue().strip()
+    log_record = json.loads(log_output)
+
+    assert log_record["message"] == "Something went wrong"
+    assert "exception" in log_record
+    assert "KeyError" in log_record["exception"]
+
+
+def test_plain_message_logging():
+    stream = io.StringIO()
+    logger = slog.get_logger("test_logger", level=logging.DEBUG, handler=logging.StreamHandler(stream))
+
+    logger.info("A plain log message")
+
+    log_output = stream.getvalue().strip()
+    log_record = json.loads(log_output)
+
+    assert log_record["message"] == "A plain log message"
+
+
+def test_structured_message_without_jsonformatter():
+    logger = logging.getLogger("plain_logger")
+    logger.setLevel(logging.DEBUG)
+    stream = io.StringIO()
+    logger.addHandler(logging.StreamHandler(stream))
+
+    logger.info(slog.M("Test message without JSONFormatter", key="value"))
+    log_output = stream.getvalue().strip()
+
+    assert "Test message without JSONFormatter" in log_output
+    assert '"key": "value"' in log_output


### PR DESCRIPTION
## Summary by Sourcery

Introduce a structured logging utility built on Python's standard logging module, including span-based contextual logging and JSON-formatted output.

New Features:
- Add adjunct.slog module providing span-based contextual logging and JSON-formatted log records.
- Add helper M class for attaching structured metadata to log messages and integrating with both JSON and plain formatters.
- Expose get_logger convenience function to create preconfigured JSON-logging loggers.

Build:
- Relax Ruff linting rules for tests to allow print-style logging checks and bare except blocks where needed.

Documentation:
- Add MkDocs documentation page for the new adjunct.slog module and include it in the navigation.

Tests:
- Add unit tests covering structured logging, span propagation and nesting, exception logging, and behavior without the JSON formatter.