### PR TITLE
jsonutils: a function for parsing multiple JSON documents

### DIFF
--- a/docs/adjunct.jsonutils.md
+++ b/docs/adjunct.jsonutils.md
@@ -1,0 +1,6 @@
+# adjunct.jsonutils
+
+::: adjunct.jsonutils
+    options:
+      show_root_heading: false
+      show_source: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - adjunct.fixtureutils.md
       - adjunct.gravatar.md
       - adjunct.html.md
+      - adjunct.jsonutils.md
       - adjunct.netstrings.md
       - adjunct.oembed.md
       - adjunct.ogp.md

--- a/src/adjunct/jsonutils.py
+++ b/src/adjunct/jsonutils.py
@@ -1,0 +1,40 @@
+import json
+import typing as t
+
+
+def load_json_documents(payloads: str) -> t.Iterator[dict | list]:
+    """Load multiple JSON documents from a string.
+
+    Each JSON document is expected to be separated by whitespace or newlines.
+
+    This is useful for processing streams of JSON objects, such as logs or data
+    exports, where each line or block represents a separate entity.
+
+    Args:
+        payloads: A text stream containing JSON documents.
+
+    Yields:
+        Parsed JSON objects/lists.
+
+    Examples:
+        >>> json_stream = '''
+        ... {"name": "Alice"}
+        ... {"name": "Bob"}
+        ... [1, 2, 3]
+        ... '''
+        >>> for doc in load_json_documents(json_stream):
+        ...     print(doc)
+        {'name': 'Alice'}
+        {'name': 'Bob'}
+        [1, 2, 3]
+    """
+
+    decoder = json.JSONDecoder()
+    idx = 0
+    while True:
+        if idx >= len(payloads):
+            break
+        payloads = payloads.lstrip()
+        obj, idx = decoder.raw_decode(payloads)
+        yield obj
+        payloads = payloads[idx:]

--- a/src/adjunct/jsonutils.py
+++ b/src/adjunct/jsonutils.py
@@ -30,11 +30,10 @@ def load_json_documents(payloads: str) -> t.Iterator[dict | list]:
     """
 
     decoder = json.JSONDecoder()
-    idx = 0
     while True:
-        if idx >= len(payloads):
-            break
         payloads = payloads.lstrip()
+        if not payloads:
+            break
         obj, idx = decoder.raw_decode(payloads)
         yield obj
         payloads = payloads[idx:]

--- a/tests/test_jsonutils.py
+++ b/tests/test_jsonutils.py
@@ -1,0 +1,17 @@
+from adjunct import jsonutils
+
+
+def test_is_valid_json():
+    json_stream = """
+    {"name": "Alice"}
+    {"name": "Bob"}
+    [1, 2, 3]
+    """
+    expected_outputs = [
+        {"name": "Alice"},
+        {"name": "Bob"},
+        [1, 2, 3],
+    ]
+
+    results = list(jsonutils.load_json_documents(json_stream))
+    assert results == expected_outputs


### PR DESCRIPTION
## Summary by Sourcery

Add utilities and documentation for parsing multiple JSON documents from a single string input.

New Features:
- Introduce load_json_documents helper to iterate over multiple JSON documents contained in a single text stream.

Documentation:
- Add jsonutils module documentation and include it in the MkDocs navigation.

Tests:
- Add unit test covering parsing multiple JSON objects and arrays from a multiline JSON stream.