### PR TITLE
slog: account for some edge cases

### DIFF
--- a/tests/tests/test_slog.py
+++ b/tests/tests/test_slog.py
@@ -5,9 +5,18 @@ import logging
 from adjunct import slog
 
 
-def test_structured_message_logging():
+def get_logger(name: str) -> tuple[io.StringIO, logging.Logger]:
     stream = io.StringIO()
-    logger = slog.get_logger("test_logger", level=logging.DEBUG, handler=logging.StreamHandler(stream))
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler(stream)
+    slog.JSONFormatter.configure_handler(handler)
+    logger.addHandler(handler)
+    return stream, logger
+
+
+def test_structured_message_logging():
+    stream, logger = get_logger("structured_message_logger")
 
     logger.info(slog.M("Test message", user="alice", action="login"))
 
@@ -21,8 +30,7 @@ def test_structured_message_logging():
 
 
 def test_span_metadata_in_logging():
-    stream = io.StringIO()
-    logger = slog.get_logger("test_logger", level=logging.DEBUG, handler=logging.StreamHandler(stream))
+    stream, logger = get_logger("span_metadata_logger")
 
     with slog.span(request_id="12345", user_id="alice"):
         logger.info(slog.M("User action", action="update_profile"))
@@ -37,18 +45,19 @@ def test_span_metadata_in_logging():
 
 
 def test_nested_spans_logging():
-    stream = io.StringIO()
-    logger = slog.get_logger("test_logger", level=logging.DEBUG, handler=logging.StreamHandler(stream))
+    stream, logger = get_logger("nested_spans_logger")
 
     with slog.span(request_id="12345"):
         logger.info(slog.M("Outer span message"))
         with slog.span(user_id="alice"):
             logger.info(slog.M("Nested span message", action="delete_account"))
+        logger.info(slog.M("Outer span message after nested"))
 
     log_output = stream.getvalue().strip()
     log_lines = log_output.splitlines()
     outer_log_record = json.loads(log_lines[0])
     nested_log_record = json.loads(log_lines[1])
+    after_nested_log_record = json.loads(log_lines[2])
 
     assert outer_log_record["message"] == "Outer span message"
     assert outer_log_record["request_id"] == "12345"
@@ -60,15 +69,20 @@ def test_nested_spans_logging():
     assert nested_log_record["action"] == "delete_account"
 
     assert outer_log_record["spanId"] != nested_log_record["spanId"]
+    assert nested_log_record["parentSpanId"] == outer_log_record["spanId"]
+
+    assert after_nested_log_record["message"] == "Outer span message after nested"
+    assert after_nested_log_record["request_id"] == "12345"
+    assert "user_id" not in after_nested_log_record  # no leakage from nested span
+    assert after_nested_log_record["spanId"] == outer_log_record["spanId"]
 
 
 def test_exception_logging():
-    stream = io.StringIO()
-    logger = slog.get_logger("test_logger", level=logging.DEBUG, handler=logging.StreamHandler(stream))
+    stream, logger = get_logger("exception_logger")
 
     try:
-        raise KeyError("Test exception")
-    except:
+        raise KeyError("Test exception")  # noqa: TRY301
+    except KeyError:
         logger.exception("Something went wrong")
 
     log_output = stream.getvalue().strip()
@@ -80,8 +94,7 @@ def test_exception_logging():
 
 
 def test_plain_message_logging():
-    stream = io.StringIO()
-    logger = slog.get_logger("test_logger", level=logging.DEBUG, handler=logging.StreamHandler(stream))
+    stream, logger = get_logger("plain_message_logger")
 
     logger.info("A plain log message")
 
@@ -89,6 +102,19 @@ def test_plain_message_logging():
     log_record = json.loads(log_output)
 
     assert log_record["message"] == "A plain log message"
+
+
+def test_plain_message_with_span():
+    stream, logger = get_logger("plain_message_with_span_logger")
+
+    with slog.span(session_id="sess-001"):
+        logger.info("A plain log message within a span")
+
+    log_output = stream.getvalue().strip()
+    log_record = json.loads(log_output)
+
+    assert log_record["message"] == "A plain log message within a span"
+    assert log_record["session_id"] == "sess-001"
 
 
 def test_structured_message_without_jsonformatter():
@@ -102,3 +128,34 @@ def test_structured_message_without_jsonformatter():
 
     assert "Test message without JSONFormatter" in log_output
     assert '"key": "value"' in log_output
+
+
+def test_m_without_metadata():
+    m = slog.M("Simple message")
+    assert str(m) == "Simple message"
+
+
+def test_m_with_metadata():
+    m1 = slog.M("Outer message with metadata", user="bob", action="view")
+    log_str = str(m1)
+    assert log_str.startswith("Outer message with metadata | ")
+    _, json_part = log_str.split(" | ", 1)
+    m1_data = json.loads(json_part)
+    assert len(m1_data) == 3
+    assert m1_data["user"] == "bob"
+    assert m1_data["action"] == "view"
+    print(m1_data)
+    assert "spanId" in m1_data
+    assert "parentSpanId" not in m1_data
+
+    with slog.span(request_id="abc123"):
+        m2 = slog.M("Message with metadata", user="bob")
+        log_str = str(m2)
+    assert log_str.startswith("Message with metadata | ")
+    _, json_part = log_str.split(" | ", 1)
+    m2_data = json.loads(json_part)
+    assert len(m2_data) == 4
+    assert m2_data["request_id"] == "abc123"
+    assert m2_data["user"] == "bob"
+    assert m2_data["spanId"] != m1_data["spanId"]
+    assert m2_data["parentSpanId"] == m1_data["spanId"]

--- a/tests/tests/test_slog.py
+++ b/tests/tests/test_slog.py
@@ -55,6 +55,7 @@ def test_nested_spans_logging():
 
     log_output = stream.getvalue().strip()
     log_lines = log_output.splitlines()
+    assert len(log_lines) == 3
     outer_log_record = json.loads(log_lines[0])
     nested_log_record = json.loads(log_lines[1])
     after_nested_log_record = json.loads(log_lines[2])
@@ -144,7 +145,6 @@ def test_m_with_metadata():
     assert len(m1_data) == 3
     assert m1_data["user"] == "bob"
     assert m1_data["action"] == "view"
-    print(m1_data)
     assert "spanId" in m1_data
     assert "parentSpanId" not in m1_data
 


### PR DESCRIPTION
In #39, Sourcery pointed out some good issues, but they're all ones that I'd prefer to deal with in a separate PR.

## Summary by Sourcery

Refine slog span handling and logging behavior while expanding test coverage for edge cases.

New Features:
- Add a SpanContextFilter to capture span context at log record emit time and attach it to records.
- Provide a JSONFormatter.configure_handler helper to configure handlers with JSON formatting and span context filtering.

Bug Fixes:
- Ensure span metadata does not leak from nested spans back into the outer span's log records.
- Include span context and custom metadata when logging plain string messages within an active span.
- Stabilize span context handling for asynchronous or queued handlers by decoupling it from evaluation time.

Enhancements:
- Initialize the span stack with type-annotated constructor and use dict union for merging metadata in JSONFormatter.
- Simplify logger setup in tests by centralizing configuration through a shared helper function and removing get_logger from the public API surface.

Tests:
- Extend slog tests to cover nested span parent-child relationships, span leakage prevention, plain messages under spans, and stringification of M with and without metadata.