### PR TITLE
Switch to ChainMap to reduce garbage generation

### DIFF
--- a/src/adjunct/slog.py
+++ b/src/adjunct/slog.py
@@ -144,7 +144,7 @@ class JSONFormatter(logging.Formatter):
         # Prefer span context captured at emit time (from SpanContextFilter),
         # with a fallback to the current span if SpanContextFilter is not used.
         ctx = getattr(record, "_adjunct_slog_ctx", span.top())
-        record_dict: t.MutableMapping[str, Scalar] = {
+        record_dict: dict[str, Scalar] = {
             "timestamp": self.formatTime(record, self.datefmt),
             "level": record.levelname,
             "logger": record.name,

--- a/src/adjunct/slog.py
+++ b/src/adjunct/slog.py
@@ -42,10 +42,12 @@ Note:
 """
 
 import base64
+import collections
 import json
 import logging
 import os
 import threading
+import typing as t
 
 Scalar = str | int | float | bool | None
 
@@ -59,9 +61,11 @@ class _SpanStack(threading.local):
 
     def __init__(self) -> None:
         super().__init__()
-        self._stack: list[dict[str, Scalar]] = [{"spanId": _generate_span_id()}]
+        self._stack: list[t.MutableMapping[str, Scalar]] = [
+            collections.ChainMap({"spanId": _generate_span_id()}),
+        ]
 
-    def top(self) -> dict[str, Scalar]:
+    def top(self) -> t.MutableMapping[str, Scalar]:
         return self._stack[-1]
 
     def extend(self, **kwargs: Scalar) -> None:
@@ -76,7 +80,11 @@ class _SpanStack(threading.local):
 
     def __call__(self, /, **kwargs: Scalar) -> "_SpanStack":
         top = self._stack[-1]
-        ctx = {**top, **kwargs, "spanId": _generate_span_id(), "parentSpanId": top["spanId"]}
+        ctx = collections.ChainMap(
+            {"spanId": _generate_span_id(), "parentSpanId": top["spanId"]},
+            kwargs,
+            top,
+        )
         self._stack.append(ctx)
         return self
 
@@ -136,12 +144,12 @@ class JSONFormatter(logging.Formatter):
         # Prefer span context captured at emit time (from SpanContextFilter),
         # with a fallback to the current span if SpanContextFilter is not used.
         ctx = getattr(record, "_adjunct_slog_ctx", span.top())
-        record_dict: dict[str, Scalar] = {
+        record_dict: t.MutableMapping[str, Scalar] = {
             "timestamp": self.formatTime(record, self.datefmt),
             "level": record.levelname,
             "logger": record.name,
-            **ctx,
         }
+        chained = collections.ChainMap(record_dict, ctx)
         if isinstance(record.msg, M):
             record_dict |= record.msg.metadata
             record_dict["message"] = record.msg.message
@@ -149,7 +157,7 @@ class JSONFormatter(logging.Formatter):
             record_dict["message"] = record.getMessage()
         if record.exc_info:
             record_dict["exception"] = self.formatException(record.exc_info)
-        return json.dumps(record_dict)
+        return json.dumps(dict(chained))
 
     @classmethod
     def configure_handler(cls, handler: logging.Handler) -> None:


### PR DESCRIPTION
## Summary by Sourcery

Switch span context storage and log record assembly to use ChainMap-based mappings to reduce intermediate dict allocations while preserving existing logging behaviour.

Enhancements:
- Use ChainMap for span stack frames and context propagation instead of copying dictionaries on each span.
- Assemble log record context via a ChainMap overlay to avoid creating new dicts until JSON serialization time.