### PR TITLE
slog: tighten logfmt support

### DIFF
--- a/src/adjunct/slog.py
+++ b/src/adjunct/slog.py
@@ -239,24 +239,23 @@ class LogfmtFormatter(_BaseFormatter):
         Returns:
             A logfmt-formatted string representing the log record.
         """
-        return " ".join(f"{key}={self._escape(value)}" for key, value in record_dict.items())
+        return " ".join(self._escape(record_dict.items()))
 
-    def _escape(self, value: Scalar) -> str:
-        """Escape a value for logfmt output.
+    def _escape(self, pairs: t.Iterable[tuple[str, Scalar]]) -> t.Iterator[str]:
+        """Escape key/value pairs for logfmt output.
 
         Args:
-            value: The value to escape.
+            pairs: The key/value pairs to escape.
 
-        Returns:
-            The escaped value.
+        Yields:
+            The escaped key/value.
         """
-
-        if value is True:
-            return "true"
-        if value is False:
-            return "false"
-        if value is None:
-            return "null"
-        if isinstance(value, (int, float)):
-            return str(value)
-        return f'"{value.translate(self._escape_table)}"'
+        for key, value in pairs:
+            if value is None or value is False:
+                continue
+            if value is True:
+                yield key
+            elif isinstance(value, (int, float)):
+                yield f"{key}={value}"
+            elif isinstance(value, str):
+                yield f'{key}="{value.translate(self._escape_table)}"'

--- a/tests/test_slog.py
+++ b/tests/test_slog.py
@@ -164,16 +164,18 @@ def test_logfmt_formatter():
 def test_logfmt_with_scalars():
     handler, logger = get_logfmt_logger("logfmt_scalars_logger")
 
-    logger.info(slog.M("Logfmt scalars", count=42, success=True, ratio=0.75, existence=None, lies=False))
+    logger.info(slog.M("Logfmt scalars", count=42, success=True, zero=0, one=1, ratio=0.75, existence=None, lies=False))
 
     log_record = handler.get_logfmt_record(0)
 
     assert 'message="Logfmt scalars"' in log_record
     assert "count=42" in log_record
-    assert "success=true" in log_record
-    assert "lies=false" in log_record
+    assert "success" in log_record
+    assert "lies" not in log_record
     assert "ratio=0.75" in log_record
-    assert "existence=null" in log_record
+    assert "zero=0" in log_record
+    assert "one=1" in log_record
+    assert "existence" not in log_record
 
 
 def test_m_without_metadata():


### PR DESCRIPTION
After reading over the spec inf https://pkg.go.dev/github.com/kr/logfmt, I suspect that while my original implementation was technically correct, according to the original blog post, and it looks to be what logrus, the Go logging library, does, treating `True` as an indication to just write out the key name and `False` and `None` as an indication to omit the field is normal practice.

## Summary by Sourcery

Adjust slog logfmt serialization semantics to better follow common logfmt conventions for boolean and null values.

Bug Fixes:
- Treat True values as bare keys and omit fields with False or None values when serializing logfmt records.

Enhancements:
- Refactor logfmt serialization to escape and format key/value pairs in a streaming fashion rather than value-by-value.

Tests:
- Update logfmt scalar tests to cover new boolean, null, and numeric serialization behavior.