### PR TITLE
Save my eyes by adding automatic dark mode support to the theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# adjunct
+# Adjunct
 
-_adjunct_ is a collection of miscellaneous modules.
+_Adjunct_ is a collection of miscellaneous modules.
 
 It's intended that this will eventually end up as a namespace package.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,27 @@ theme:
   icon:
     logo: octicons/key-16
   features:
+    - navigation.tabs
+    - navigation.path
     - content.code.copy
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
 
 markdown_extensions:
   - toc:


### PR DESCRIPTION
## Summary by Sourcery

Add automatic light/dark mode support to the MkDocs theme and tidy up project naming in the README.

Enhancements:
- Configure MkDocs theme palettes to support automatic, light, and dark modes with navigation improvements.

Documentation:
- Capitalize the project name consistently in the README.