### PR TITLE
Lean on typing rather than using a base class

### DIFF
--- a/src/adjunct/xmlutils.py
+++ b/src/adjunct/xmlutils.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import io
+import typing as t
 from xml.sax import saxutils
 
 
@@ -32,7 +33,7 @@ class XMLBuilder:
         string as no other sensible value can be returned.
     """
 
-    def __init__(self, out: io.TextIOBase | None = None, encoding: str = "utf-8") -> None:
+    def __init__(self, out: t.TextIO | None = None, encoding: str = "utf-8") -> None:
         self.buffer = None
         if out is None:
             self.buffer = io.StringIO()


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Broaden XMLBuilder constructor typing to accept any TextIO-compatible stream for the output parameter.