### PR TITLE
Switch from thread-local storage to a context variable for universal safe use

### DIFF
--- a/src/adjunct/slog.py
+++ b/src/adjunct/slog.py
@@ -14,41 +14,40 @@ To configure logging to use structured logging, set up a logger with
 ```python
 import logging
 
-from adjunct import slog
+from adjunct.slog JSONFormatter, M, span
 
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 handler = logging.StreamHandler()
-slog.JSONFormatter.configure_handler(handler)
+JSONFormatter.configure_handler(handler)
 logger.addHandler(handler)
 ```
 
-Both `slog.M` and `slog.span` can then be used to add structured metadata to
-log records:
+Both `M` and `span` can then be used to add structured metadata to log records:
 
 ```python
-logger.info(slog.M("User logged in", user="alice"))  # Log with metadata
-with slog.span(request_id="12345", user_id="alice"):  # Log within a span
-    logger.info(slog.M("User action", action="update_profile"))
+logger.info(M("User logged in", user="alice"))  # Log with metadata
+with span(request_id="12345", user_id="alice"):  # Log within a span
+    logger.info(M("User action", action="update_profile"))
 ```
 
-`slog.M` and `slog.JSONFormatter` work together to produce log records
-that include the specified metadata and span context, but can both be used
-independently if desired. Using `slog.M` will produce a stringified message
-that includes the metadata in JSON, even without `slog.JSONFormatter`.
+`M` and `JSONFormatter` work together to produce log records that include the
+specified metadata and span context, but can both be used independently if
+desired. Using `M` will produce a stringified message that includes the
+metadata in JSON, even without `JSONFormatter`.
 
-An alternative is `slog.LogfmtFormatter`, which formats log records in
-[logfmt][] format. It works just like `slog.JSONFormatter`, but produces
-log records in logfmt instead of JSON.
+An alternative is `LogfmtFormatter`, which formats log records in [logfmt][]
+format. It works just like `JSONFormatter`, but produces log records in logfmt
+instead of JSON.
 
 [logfmt]: https://brandur.org/logfmt
 
 Note:
     The keys `spanId` and `parentSpanId` are reserved for span tracking and
-    should not be used in metadata passed to `slog.M` or `slog.span`. They
-    are named to match OpenTelemetry conventions, though this module does not
-    implement OpenTelemetry itself nor aims to be compatible with it.
+    should not be used in metadata passed to `M` or `span`. They are named to
+    match OpenTelemetry conventions, though this module does not implement
+    OpenTelemetry itself nor aims to be compatible with it.
 """
 
 import base64
@@ -89,6 +88,10 @@ class _SpanStack:
             _stack.set(stack)
             return stack
 
+    @_stack.setter
+    def _stack(self, stack: Stack) -> None:
+        _stack.set(stack)
+
     @property
     def top(self) -> t.MutableMapping[str, Scalar]:
         return self._stack[-1]
@@ -101,7 +104,8 @@ class _SpanStack:
         return self
 
     def __exit__(self, *_) -> None:
-        self._stack.pop()
+        # See the comment in __call__ for details.
+        self._stack = self._stack[:-1]
 
     def __call__(self, /, **kwargs: Scalar) -> "_SpanStack":
         stack = self._stack
@@ -111,7 +115,11 @@ class _SpanStack:
             kwargs,
             top,
         )
-        stack.append(ctx)
+        # Apparently, the values of context vars can bleed across async tasks,
+        # which is a problem if what you're storing is something mutable like
+        # a list. Let's hope the cost of entering an exiting spans never
+        # becomes too bit a deal...
+        self._stack = [*stack, ctx]
         return self
 
 


### PR DESCRIPTION
## Summary by Sourcery

Switch logging span storage from thread-local state to context-local state and update documentation and examples to reflect the new, simpler public API.

Bug Fixes:
- Ensure span context is safely isolated across async tasks by using context variables instead of thread-local storage.

Enhancements:
- Refactor span stack management to use a context-aware stack implementation backed by contextvars.
- Simplify usage by encouraging direct imports of JSONFormatter, M, span, and LogfmtFormatter instead of module-qualified access.

Documentation:
- Update structured logging usage examples and narrative docs to match the new import style and remove the limitation about async incompatibility.