### PR TITLE
dbhelpers: add a test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ exclude_lines = [
   "if 0:",
   "if __name__ == .__main__.:",
   "pass",
+  "\\.\\.\\.",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ exclude_lines = [
   "if 0:",
   "if __name__ == .__main__.:",
   "pass",
-  "\\.\\.\\.",
+  "^\\s*\\.\\.\\.\\s*$",
 ]
 
 [tool.mypy]

--- a/tests/test_dbhelpers.py
+++ b/tests/test_dbhelpers.py
@@ -1,0 +1,52 @@
+import sqlite3
+
+import pytest
+
+from adjunct import dbhelpers
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    conn = sqlite3.connect(tmp_path / "fixture.db")
+    cur = conn.cursor()
+    cur.execute("""
+        CREATE TABLE people (
+            id   INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL
+        )
+        """)
+    cur.executemany(
+        "INSERT INTO people (name) VALUES (?)",
+        [("tom",), ("dick",), ("harry",)],
+    )
+    conn.commit()
+    cur.close()
+    yield conn
+    conn.close()
+
+
+def test_query(tmp_db):
+    ids_names = list(dbhelpers.query(tmp_db, "SELECT id, name FROM people ORDER BY id"))
+    assert ids_names == [(1, "tom"), (2, "dick"), (3, "harry")]
+
+
+def test_query_row(tmp_db):
+    assert dbhelpers.query_row(tmp_db, "SELECT id FROM people WHERE name = ?", ("harry",)) == (3,)
+
+
+def test_query_row_no_match(tmp_db):
+    assert dbhelpers.query_row(tmp_db, "SELECT id FROM people WHERE name = ?", ("alice",)) is None
+
+
+def test_query_value(tmp_db):
+    assert dbhelpers.query_value(tmp_db, "SELECT id FROM people WHERE name = ?", ("harry",)) == 3
+
+
+def test_query_value_no_match(tmp_db):
+    assert dbhelpers.query_value(tmp_db, "SELECT id FROM people WHERE name = ?", ("alice",)) is None
+
+
+def test_execute(tmp_db):
+    new_id = dbhelpers.execute(tmp_db, "INSERT INTO people (name) VALUES (?)", ("alice",))
+    assert isinstance(new_id, int)
+    assert dbhelpers.query_value(tmp_db, "SELECT id FROM people WHERE name = ?", ("alice",)) == new_id


### PR DESCRIPTION
## Summary by Sourcery

Add a test suite for the dbhelpers module and adjust coverage configuration for ellipsis lines.

Build:
- Update coverage configuration to ignore ellipsis lines in pyproject.toml.

Tests:
- Introduce pytest-based tests for dbhelpers query, query_row, query_value, and execute helpers against a temporary SQLite database fixture.