### PR TITLE
Use a separate task for coverage (for faster testing)

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ tidy:
 test:
 	@uv run --frozen pytest
 
+# run the tests with coverage
+coverage:
+	@uv run --frozen pytest --cov=src --cov-report=term-missing
+
 # run the typechecker
 typecheck:
 	@uv run --frozen mypy src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ ban-relative-imports = "all"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-ra -q --doctest-modules --cov=adjunct --junitxml=tests/results.xml --cov-report html"
+addopts = "-ra -q --junitxml=tests/results.xml"
 junit_logging = "out-err"
 junit_family = "xunit2"
 pythonpath = ["src"]


### PR DESCRIPTION
## Summary by Sourcery

Separate coverage collection from the default pytest run to speed up normal tests while still providing an explicit coverage task.

New Features:
- Add a dedicated just task to run tests with coverage reporting.

Enhancements:
- Update pytest configuration to remove automatic coverage collection from the default test run and only keep JUnit XML reporting.