### PR TITLE
More test parametrisation and a WSGI fixture

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,18 +7,22 @@ devel:
 	@uv sync --frozen
 
 # tidy everything with ruff
+[group("Analysis/Fixing")]
 tidy:
 	@uv run --frozen ruff check --fix
 
 # run the test suite
+[group("Testing")]
 test:
 	@uv run --frozen pytest
 
 # run the tests with coverage
+[group("Testing")]
 coverage:
 	@uv run --frozen pytest --cov=src --cov-report=term-missing
 
 # run the typechecker
+[group("Analysis/Fixing")]
 typecheck:
 	@uv run --frozen mypy src
 
@@ -33,6 +37,7 @@ tools:
 	@uv tool install tox --with tox-uv
 
 # run the mkdocs server
+[group("Documentation")]
 serve-docs:
 	@# --livereload is needed because of https://github.com/squidfunk/mkdocs-material/issues/8478
 	@uv run mkdocs serve --livereload

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,30 +26,31 @@ DISCOVER_FEEDS_ANCHORS = b"""<!DOCTYPE html>
 """
 
 
+def app(environ, start_response):
+    headers = [("Content-Type", "text/plain; charset=UTF-8")]
+    match environ["PATH_INFO"]:
+        case "/400":
+            status = "400 Bad Request"
+            body = [b"Bad Request"]
+        case "/500":
+            status = "500 Internal Server Error"
+            body = [b"Internal Server Error"]
+        case "/discoverfeeds":
+            status = "200 OK"
+            headers = [("Content-Type", "text/html; charset=UTF-8")]
+            body = [DISCOVER_FEEDS]
+        case "/discoveranchorfeeds":
+            status = "200 OK"
+            headers = [("Content-Type", "text/html; charset=UTF-8")]
+            body = [DISCOVER_FEEDS_ANCHORS]
+        case _:
+            status = "200 OK"
+            body = [b"Fixture App Response"]
+    start_response(status, headers)
+    return body
+
+
 @pytest.fixture(scope="package")
 def fixture_app():
-    def app(environ, start_response):
-        headers = [("Content-Type", "text/plain; charset=UTF-8")]
-        match environ["PATH_INFO"]:
-            case "/400":
-                status = "400 Bad Request"
-                body = [b"Bad Request"]
-            case "/500":
-                status = "500 Internal Server Error"
-                body = [b"Internal Server Error"]
-            case "/discoverfeeds":
-                status = "200 OK"
-                headers = [("Content-Type", "text/html; charset=UTF-8")]
-                body = [DISCOVER_FEEDS]
-            case "/discoveranchorfeeds":
-                status = "200 OK"
-                headers = [("Content-Type", "text/html; charset=UTF-8")]
-                body = [DISCOVER_FEEDS_ANCHORS]
-            case _:
-                status = "200 OK"
-                body = [b"Fixture App Response"]
-        start_response(status, headers)
-        return body
-
     with fixtureutils.fixture(app) as addr:
         yield addr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+import pytest
+
+from adjunct import fixtureutils
+
+DISCOVER_FEEDS = b"""<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="alternate" type="application/rss+xml" title="RSS" href="/feeds/rss">
+        <link rel="alternate" type="application/atom+xml" title="Atom" href="/feeds/atom">
+    </head>
+</html>
+"""
+
+DISCOVER_FEEDS_ANCHORS = b"""<!DOCTYPE html>
+<html>
+    <head></head>
+    <body>
+        <a href="/feeds/rss">RSS Feed</a>
+        <a href="/feeds/atom">Atom Feed</a>
+        <a href="/feeds/rss.xml">RSS Feed</a>
+        <a href="/feed.rdf">RDF Feed</a>
+        <a href="/feed.xoxo">XOXO Feed</a>
+        <a>Not a feed, not even a link</a>
+    </body>
+</html>
+"""
+
+
+@pytest.fixture(scope="package")
+def fixture_app():
+    def app(environ, start_response):
+        headers = [("Content-Type", "text/plain; charset=UTF-8")]
+        match environ["PATH_INFO"]:
+            case "/400":
+                status = "400 Bad Request"
+                body = [b"Bad Request"]
+            case "/500":
+                status = "500 Internal Server Error"
+                body = [b"Internal Server Error"]
+            case "/discoverfeeds":
+                status = "200 OK"
+                headers = [("Content-Type", "text/html; charset=UTF-8")]
+                body = [DISCOVER_FEEDS]
+            case "/discoveranchorfeeds":
+                status = "200 OK"
+                headers = [("Content-Type", "text/html; charset=UTF-8")]
+                body = [DISCOVER_FEEDS_ANCHORS]
+            case _:
+                status = "200 OK"
+                body = [b"Fixture App Response"]
+        start_response(status, headers)
+        return body
+
+    with fixtureutils.fixture(app) as addr:
+        yield addr

--- a/tests/test_discoverfeeds.py
+++ b/tests/test_discoverfeeds.py
@@ -1,60 +1,21 @@
-from adjunct import discoverfeeds, fixtureutils
+from adjunct import discoverfeeds
 
 
-def app_discover_feeds(environ, start_response):  # noqa: ARG001
-    headers = [
-        ("Content-Type", "text/html; charset=utf-8"),
-    ]
-    start_response("200 OK", headers)
-    return [
-        b"""<!DOCTYPE html>
-<html>
-    <head>
-        <link rel="alternate" type="application/rss+xml" title="RSS" href="/feeds/rss">
-        <link rel="alternate" type="application/atom+xml" title="Atom" href="/feeds/atom">
-    </head>
-</html>"""
+def test_discover_feeds(fixture_app):
+    feeds = discoverfeeds.discover_feeds(f"{fixture_app}discoverfeeds")
+    # Note: feeds are returned in priority order.
+    assert feeds == [
+        {"type": "application/atom+xml", "title": "Atom", "href": f"{fixture_app}feeds/atom"},
+        {"type": "application/rss+xml", "title": "RSS", "href": f"{fixture_app}feeds/rss"},
     ]
 
 
-def test_discover_feeds():
-    with fixtureutils.fixture(app_discover_feeds) as addr:
-        feeds = discoverfeeds.discover_feeds(addr)
-        # Note: feeds are returned in priority order.
-        assert feeds == [
-            {"type": "application/atom+xml", "title": "Atom", "href": f"{addr}feeds/atom"},
-            {"type": "application/rss+xml", "title": "RSS", "href": f"{addr}feeds/rss"},
-        ]
-
-
-def app_discover_feeds_anchors(environ, start_response):  # noqa: ARG001
-    headers = [
-        ("Content-Type", "text/html; charset=utf-8"),
+def test_discover_feeds_anchors(fixture_app):
+    feeds = discoverfeeds.discover_feeds(f"{fixture_app}discoveranchorfeeds")
+    # Note: feeds are returned in priority order.
+    assert feeds == [
+        {"type": "application/atom+xml", "title": "Atom Feed", "href": f"{fixture_app}feeds/atom"},
+        {"type": "application/rdf+xml", "title": "RDF Feed", "href": f"{fixture_app}feed.rdf"},
+        {"type": "application/rss+xml", "title": "RSS Feed", "href": f"{fixture_app}feeds/rss"},
+        {"type": "application/rss+xml", "title": "RSS Feed", "href": f"{fixture_app}feeds/rss.xml"},
     ]
-    start_response("200 OK", headers)
-    return [
-        b"""<!DOCTYPE html>
-<html>
-    <head>
-    </head>
-    <body>
-        <a href="/feeds/rss">RSS Feed</a>
-        <a href="/feeds/atom">Atom Feed</a>
-        <a href="/feeds/rss.xml">RSS Feed</a>
-        <a href="/feed.rdf">RDF Feed</a>
-        <a href="/feed.xoxo">XOXO Feed</a>
-        <a>Not a feed, not even a link</a>
-</html>"""
-    ]
-
-
-def test_discover_feeds_anchors():
-    with fixtureutils.fixture(app_discover_feeds_anchors) as addr:
-        feeds = discoverfeeds.discover_feeds(addr)
-        # Note: feeds are returned in priority order.
-        assert feeds == [
-            {"type": "application/atom+xml", "title": "Atom Feed", "href": f"{addr}feeds/atom"},
-            {"type": "application/rdf+xml", "title": "RDF Feed", "href": f"{addr}feed.rdf"},
-            {"type": "application/rss+xml", "title": "RSS Feed", "href": f"{addr}feeds/rss"},
-            {"type": "application/rss+xml", "title": "RSS Feed", "href": f"{addr}feeds/rss.xml"},
-        ]

--- a/tests/test_fixtureutils.py
+++ b/tests/test_fixtureutils.py
@@ -65,15 +65,8 @@ def test_json_response():
     assert headers_dict["Content-Type"] == "application/json; charset=UTF-8"
 
 
-def fixture_app(environ, start_response):  # noqa: ARG001
-    """
-    A simple WSGI application for testing purposes.
-    """
-    return fixtureutils.basic_response(start_response, 200, "Fixture App Response")
-
-
-def test_fixture():
-    with fixtureutils.fixture(fixture_app) as addr, urllib.request.urlopen(addr) as resp:
+def test_fixture(fixture_app):
+    with urllib.request.urlopen(fixture_app) as resp:
         body = resp.read()
         assert resp.status == 200
         assert resp.getheader("Content-Type") == "text/plain; charset=UTF-8"

--- a/tests/test_netstrings.py
+++ b/tests/test_netstrings.py
@@ -1,41 +1,37 @@
-import unittest
+import pytest
 
 from adjunct.netstrings import MalformedNetstringError, parse
 
 
-class NetstringReaderTest(unittest.TestCase):
-    def test_empty(self):
-        self.assertListEqual(parse(b""), [])
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (b"", []),
+        (b"0:,", [b""]),
+        (b"1:a,", [b"a"]),
+        (b"2:ab,", [b"ab"]),
+        (b"10:abcdezxcvb,", [b"abcdezxcvb"]),
+        (b"0:,0:,", [b"", b""]),
+        (b"1:a,1:a,", [b"a", b"a"]),
+        (b"2:ab,2:ab,", [b"ab", b"ab"]),
+    ],
+)
+def test_good(data, expected):
+    assert parse(data) == expected
 
-    def test_single(self):
-        self.assertListEqual(parse(b"0:,"), [b""])
-        self.assertListEqual(parse(b"1:a,"), [b"a"])
-        self.assertListEqual(parse(b"2:ab,"), [b"ab"])
 
-    def test_long_string(self):
-        self.assertListEqual(parse(b"10:abcdezxcvb,"), [b"abcdezxcvb"])
-
-    def test_series(self):
-        self.assertListEqual(parse(b"0:,0:,"), [b"", b""])
-        self.assertListEqual(parse(b"1:a,1:a,"), [b"a", b"a"])
-        self.assertListEqual(parse(b"2:ab,2:ab,"), [b"ab", b"ab"])
-
-    def test_length_limit(self):
-        with self.assertRaises(MalformedNetstringError):
-            parse(b"12345678901:b,")
-
-    def test_leading_zero(self):
-        with self.assertRaises(MalformedNetstringError):
-            parse(b"01:b,")
-
-    def test_bad_length(self):
-        with self.assertRaises(MalformedNetstringError):
-            parse(b"a:b,")
-
-    def test_truncation(self):
-        with self.assertRaises(MalformedNetstringError):
-            parse(b"5:abcd")
-        with self.assertRaises(MalformedNetstringError):
-            parse(b"0:")
-        with self.assertRaises(MalformedNetstringError):
-            parse(b"5:abcde")
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"12345678901:b,",
+        b"5:abcd,",
+        b"0:",
+        b"01:b,",
+        b"a:b,",
+        b"5:abcd",
+        b"5:abcde",
+    ],
+)
+def test_malformed(data):
+    with pytest.raises(MalformedNetstringError):
+        parse(data)

--- a/tests/test_oembed.py
+++ b/tests/test_oembed.py
@@ -167,5 +167,6 @@ def test_fetch_oembed_with_bad_request(fixture_app):
 
 
 def test_fetch_oembed_with_server_error(fixture_app):
-    with pytest.raises(error.HTTPError, match="Internal Server Error"):
+    with pytest.raises(error.HTTPError) as excinfo:
         fetch(f"{fixture_app}500")
+    assert excinfo.value.code == 500

--- a/tests/test_oembed.py
+++ b/tests/test_oembed.py
@@ -6,7 +6,6 @@ from urllib import error
 
 import pytest
 
-from adjunct import fixtureutils
 from adjunct.fixtureutils import make_fake_http_response
 from adjunct.oembed import (
     _build_url,
@@ -162,22 +161,11 @@ class FetchTest(unittest.TestCase):
         self.assertIsNone(fetched)
 
 
-def app_400(environ, start_response):  # noqa: ARG001
-    headers = [("Content-Type", "text/plain; charset=utf-8")]
-    start_response("400 Bad Request", headers)
-    yield b"Bad request"
+def test_fetch_oembed_with_bad_request(fixture_app):
+    fetched = fetch(f"{fixture_app}400")
+    assert fetched is None
 
 
-def app_500(environ, start_response):  # noqa: ARG001
-    headers = [("Content-Type", "text/plain; charset=utf-8")]
-    start_response("500 Internal Server Error", headers)
-    yield b"Internal server error"
-
-
-def test_fetch_oembed_with_error():
-    with fixtureutils.fixture(app_400) as addr:
-        fetched = fetch(f"{addr}/oembed")
-        assert fetched is None
-
-    with fixtureutils.fixture(app_500) as addr, pytest.raises(error.HTTPError):
-        fetch(f"{addr}/oembed")
+def test_fetch_oembed_with_server_error(fixture_app):
+    with pytest.raises(error.HTTPError, match="Internal Server Error"):
+        fetch(f"{fixture_app}500")

--- a/tests/test_opml.py
+++ b/tests/test_opml.py
@@ -12,6 +12,7 @@ class OPMLTest(unittest.TestCase):
         with open(os.path.join(HERE, "sample.opml")) as fh:
             doc = opml.parse(fh)
 
+        assert doc is not None
         self.assertTrue(doc.root)
         self.assertEqual(len(doc.attrs), 1)
         self.assertEqual(doc.attrs["title"], "Sample OPML file")


### PR DESCRIPTION
I'm trying to get rid of unittest to replace it with pytest everywhere.

## Summary by Sourcery

Migrate remaining tests toward pytest-style usage and introduce a shared WSGI fixture for HTTP-based tests.

New Features:
- Add a reusable pytest WSGI fixture that provides a test HTTP application for multiple suites.

Enhancements:
- Parametrize netstring parsing tests using pytest for clearer coverage of valid and invalid inputs.
- Group justfile tasks into logical categories for analysis, testing, and documentation workflows.

Tests:
- Refactor discoverfeeds and oembed tests to use the shared WSGI pytest fixture instead of ad hoc local apps.
- Update fixtureutils tests to rely on the new WSGI fixture entrypoint URL rather than an inline WSGI app.
- Strengthen the OPML parsing test by asserting that the parsed document object is not None.