### PR TITLE
Convert more tests to use pytest

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*,{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.toml]
+indent_style = space
+indent_size = 2

--- a/justfile
+++ b/justfile
@@ -16,6 +16,16 @@ tidy:
 test:
 	@uv run --frozen pytest
 
+# run only fast tests
+[group("Testing")]
+fast-test:
+	@uv run --frozen pytest -m "not slow"
+
+# run test suite showing the slowest of those not marked as slow
+[group("Testing")]
+test-show-slow:
+	@uv run --frozen pytest -m "not slow" --durations 10
+
 # run the tests with coverage
 [group("Testing")]
 coverage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,9 @@ junit_logging = "out-err"
 junit_family = "xunit2"
 pythonpath = ["src"]
 testpaths = ["tests"]
+markers = [
+  "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 [tool.coverage.run]
 branch = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,9 +25,18 @@ DISCOVER_FEEDS_ANCHORS = b"""<!DOCTYPE html>
 </html>
 """
 
+META = b"""<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="foo" href="bar">
+        <meta property="og:title" content="Example">
+    </head>
+</html>"""
+
 
 def app(environ, start_response):
-    headers = [("Content-Type", "text/plain; charset=UTF-8")]
+    status = "200 OK"
+    headers = [("Content-Type", "text/html; charset=UTF-8")]
     match environ["PATH_INFO"]:
         case "/400":
             status = "400 Bad Request"
@@ -36,21 +45,24 @@ def app(environ, start_response):
             status = "500 Internal Server Error"
             body = [b"Internal Server Error"]
         case "/discoverfeeds":
-            status = "200 OK"
-            headers = [("Content-Type", "text/html; charset=UTF-8")]
             body = [DISCOVER_FEEDS]
         case "/discoveranchorfeeds":
-            status = "200 OK"
-            headers = [("Content-Type", "text/html; charset=UTF-8")]
             body = [DISCOVER_FEEDS_ANCHORS]
+        case "/meta":
+            headers = [
+                ("Content-Type", "text/html; charset=utf-8"),
+                ("Link", "http://malformed.example.com/"),
+                ("Link", '<http://example.com/>; rel="bar"'),
+            ]
+            body = [META]
         case _:
-            status = "200 OK"
+            headers = [("Content-Type", "text/plain; charset=UTF-8")]
             body = [b"Fixture App Response"]
     start_response(status, headers)
     return body
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="session")
 def fixture_app():
     with fixtureutils.fixture(app) as addr:
         yield addr

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,87 +1,68 @@
 import io
-import unittest
+
+import pytest
 
 from adjunct import html
 
 
-class TestParser(unittest.TestCase):
-    def test_empty(self):
-        root = html.parse("")
-        self.assertEqual(len(root), 0)
-        self.assertDictEqual(root.attrs, {})
-
-    def test_simple(self):
-        root = html.parse("<a>")
-        self.assertEqual(len(root), 1)
-        self.assertEqual(root[0].tag, "a")
-
-    def test_simple_nesting(self):
-        root = html.parse("<b><a>")
-        self.assertEqual(len(root), 1)
-        self.assertEqual(root[0].tag, "b")
-        self.assertEqual(root[0][0].tag, "a")
-
-    def test_self_closing(self):
-        root = html.parse("<br><hr>")
-        self.assertEqual(len(root), 2)
-        self.assertEqual(root[0].tag, "br")
-        self.assertEqual(root[1].tag, "hr")
-
-    def test_text_embedding(self):
-        root = html.parse("a<br>b<hr>c")
-        self.assertEqual(len(root), 5)
-        self.assertIsInstance(root[0], str)
-        self.assertEqual(root[0], "a")
-        self.assertIsInstance(root[1], html.Element)
-        self.assertEqual(root[1].tag, "br")
-        self.assertIsInstance(root[2], str)
-        self.assertEqual(root[2], "b")
-        self.assertIsInstance(root[3], html.Element)
-        self.assertEqual(root[3].tag, "hr")
-        self.assertIsInstance(root[4], str)
-        self.assertEqual(root[4], "c")
-
-    def test_startend(self):
-        root = html.parse("<br/>")
-        self.assertEqual(len(root), 1)
-        with io.StringIO() as fh:
-            root.serialize(fh)
-            self.assertEqual(fh.getvalue(), "<br>")
-
-    def test_closing_extra(self):
-        root = html.parse("<br></br>")
-        self.assertEqual(len(root), 1)
-        with io.StringIO() as fh:
-            root.serialize(fh)
-            self.assertEqual(fh.getvalue(), "<br>")
-
-    def test_unbalanced(self):
-        root = html.parse("<p><div></p></div>")
-        with io.StringIO() as fh:
-            root.serialize(fh)
-            self.assertEqual(fh.getvalue(), "<p><div></div></p>")
+def test_empty():
+    root = html.parse("")
+    assert len(root) == 0
+    assert root.attrs == {}
 
 
-class TestElement(unittest.TestCase):
-    def assert_html(self, a, b):
-        with io.StringIO() as fh:
-            html.parse(a).serialize(fh)
-            self.assertEqual(fh.getvalue(), b)
+def test_simple():
+    root = html.parse("<a>")
+    assert len(root) == 1
+    assert root[0].tag == "a"
 
-    def test_simple(self):
-        self.assert_html("", "")
-        self.assert_html("<a>", "<a></a>")
-        self.assert_html("<br>", "<br>")
 
-    def test_attrs(self):
-        self.assert_html(
-            '<a href="foo">bar</a>',
-            '<a href="foo">bar</a>',
-        )
-        self.assert_html(
-            "<a name>bar</a>",
-            "<a name>bar</a>",
-        )
+def test_simple_nesting():
+    root = html.parse("<b><a>")
+    assert len(root) == 1
+    assert root[0].tag == "b"
+    assert root[0][0].tag == "a"
+
+
+def test_self_closing():
+    root = html.parse("<br><hr>")
+    assert len(root) == 2
+    assert root[0].tag == "br"
+    assert root[1].tag == "hr"
+
+
+def test_text_embedding():
+    root = html.parse("a<br>b<hr>c")
+    assert len(root) == 5
+    assert isinstance(root[0], str)
+    assert root[0] == "a"
+    assert isinstance(root[1], html.Element)
+    assert root[1].tag == "br"
+    assert isinstance(root[2], str)
+    assert root[2] == "b"
+    assert isinstance(root[3], html.Element)
+    assert root[3].tag == "hr"
+    assert isinstance(root[4], str)
+    assert root[4] == "c"
+
+
+@pytest.mark.parametrize(
+    ("src", "length", "expected"),
+    [
+        ("<br/>", 1, "<br>"),
+        ("<br></br>", 1, "<br>"),
+        ("<p><div></p></div>", 1, "<p><div></div></p>"),
+        ("<a>", 1, "<a></a>"),
+        ('<a href="foo">bar</a>', 1, '<a href="foo">bar</a>'),
+        ("<a name>bar</a>", 1, "<a name>bar</a>"),
+    ],
+)
+def test_serialisation(src, length, expected):
+    root = html.parse(src)
+    assert len(root) == length
+    with io.StringIO() as fh:
+        root.serialize(fh)
+        assert fh.getvalue() == expected
 
 
 def test_no_file_object_serialiser():

--- a/tests/test_oembed.py
+++ b/tests/test_oembed.py
@@ -16,14 +16,14 @@ from adjunct.oembed import (
 )
 
 
-class BuildUrlTest(unittest.TestCase):
-    def test_base(self):
-        self.assertEqual(_build_url("foo", None, None), "foo")
+def test_base():
+    assert _build_url("foo", None, None) == "foo"
 
-    def test_dimension(self):
-        self.assertEqual(_build_url("foo", 5, None), "foo&maxwidth=5")
-        self.assertEqual(_build_url("foo", None, 8), "foo&maxheight=8")
-        self.assertEqual(_build_url("foo", 5, 8), "foo&maxwidth=5&maxheight=8")
+
+def test_dimension():
+    assert _build_url("foo", 5, None) == "foo&maxwidth=5"
+    assert _build_url("foo", None, 8) == "foo&maxheight=8"
+    assert _build_url("foo", 5, 8) == "foo&maxwidth=5&maxheight=8"
 
 
 LINKS_WITHOUT = [
@@ -50,38 +50,42 @@ LINKS_WITH = [
 ]
 
 
+def test_none():
+    assert _find_first_oembed_link(LINKS_WITHOUT) is None
+
+
+def test_find():
+    links = [
+        *LINKS_WITHOUT,
+        {
+            "href": "http://www.example.com/oembed?format=json",
+            "rel": "alternate",
+            "title": "JSON Example",
+            "type": "application/json+oembed",
+        },
+        {
+            "href": "http://www.example.com/oembed?format=xml",
+            "rel": "alternate",
+            "title": "XML Example",
+            "type": "text/xml+oembed",
+        },
+    ]
+    result = _find_first_oembed_link(links)
+    assert result == "http://www.example.com/oembed?format=json"
+
+
+def test_no_href():
+    links = [*LINKS_WITHOUT, *LINKS_WITH]
+    result = _find_first_oembed_link(links)
+    assert result == "http://www.example.com/oembed?format=xml"
+
+
+def test_get_oembed_none():
+    result = get_oembed(LINKS_WITHOUT)
+    assert result is None
+
+
 class OEmbedFinderTest(unittest.TestCase):
-    def test_none(self):
-        self.assertIsNone(_find_first_oembed_link(LINKS_WITHOUT))
-
-    def test_find(self):
-        links = [
-            *LINKS_WITHOUT,
-            {
-                "href": "http://www.example.com/oembed?format=json",
-                "rel": "alternate",
-                "title": "JSON Example",
-                "type": "application/json+oembed",
-            },
-            {
-                "href": "http://www.example.com/oembed?format=xml",
-                "rel": "alternate",
-                "title": "XML Example",
-                "type": "text/xml+oembed",
-            },
-        ]
-        result = _find_first_oembed_link(links)
-        self.assertEqual(result, "http://www.example.com/oembed?format=json")
-
-    def test_no_href(self):
-        links = [*LINKS_WITHOUT, *LINKS_WITH]
-        result = _find_first_oembed_link(links)
-        self.assertEqual(result, "http://www.example.com/oembed?format=xml")
-
-    def test_get_oembed_none(self):
-        result = get_oembed(LINKS_WITHOUT)
-        self.assertIsNone(result)
-
     @mock.patch("urllib.request.urlopen")
     def test_get_oembed(self, mock_urlopen):
         doc = {
@@ -99,10 +103,9 @@ class OEmbedFinderTest(unittest.TestCase):
         self.assertDictEqual(result, doc)
 
 
-class OEmbedXMLParserTest(unittest.TestCase):
-    def test_parse(self):
-        fh = io.StringIO(
-            """<?xml version="1.0" encoding="utf-8"?>
+def test_parse():
+    fh = io.StringIO(
+        """<?xml version="1.0" encoding="utf-8"?>
 <oembed>
     <version>1.0</version>
     <type>photo</type>
@@ -112,18 +115,15 @@ class OEmbedXMLParserTest(unittest.TestCase):
     <width>300</width>
 </oembed>
 """
-        )
-        fields = _parse_xml_oembed_response(fh)
-        self.assertDictEqual(
-            fields,
-            {
-                "version": "1.0",
-                "type": "photo",
-                "title": "This is a title",
-                "width": "300",
-                "height": "300",
-            },
-        )
+    )
+    fields = _parse_xml_oembed_response(fh)
+    assert fields == {
+        "version": "1.0",
+        "type": "photo",
+        "title": "This is a title",
+        "width": "300",
+        "height": "300",
+    }
 
 
 def make_response(dct, content_type="application/json+oembed; charset=UTF-8"):

--- a/tests/test_ogp.py
+++ b/tests/test_ogp.py
@@ -27,7 +27,7 @@ def test_access(ogp_properties):
 
 def test_invalid(ogp_properties):
     _, parsed = ogp_properties
-    assert len(list(ogp.find(parsed, "audio"))) == 0
+    assert not list(ogp.find(parsed, "audio"))
 
 
 def test_video(ogp_properties):

--- a/tests/test_ogp.py
+++ b/tests/test_ogp.py
@@ -1,40 +1,46 @@
 import os.path
-import unittest
+
+import pytest
 
 from adjunct import discovery, ogp
 
 HERE = os.path.dirname(__file__)
 
 
-class TestOPG(unittest.TestCase):
-    maxDiff = None
+@pytest.fixture(scope="session")
+def ogp_properties():
+    with open(os.path.join(HERE, "ogp.html"), "rb") as fh:
+        raw = discovery.Extractor.extract(fh).properties
+    return (raw, ogp.parse(raw))
 
-    def setUp(self):
-        with open(os.path.join(HERE, "ogp.html"), "rb") as fh:
-            self.raw_properties = discovery.Extractor.extract(fh).properties
-        self.properties = ogp.parse(self.raw_properties)
 
-    def test_size(self):
-        self.assertEqual(len(self.raw_properties), 11)
-        self.assertEqual(len(self.properties), 7)
+def test_size(ogp_properties):
+    raw, parsed = ogp_properties
+    assert len(raw) == 11
+    assert len(parsed) == 7
 
-    def test_access(self):
-        self.assertEqual(len(list(ogp.find(self.properties, "type", "song"))), 1)
 
-    def test_invalid(self):
-        self.assertEqual(len(list(ogp.find(self.properties, "audio"))), 0)
+def test_access(ogp_properties):
+    _, parsed = ogp_properties
+    assert len(list(ogp.find(parsed, "type", "song"))) == 1
 
-    def test_video(self):
-        videos = list(ogp.find(self.properties, "video"))
-        self.assertEqual(len(videos), 1)
-        self.assertEqual(videos[0].value, videos[0].metadata["secure_url"])
-        self.assertSetEqual(
-            set(videos[0].metadata.keys()),
-            {"secure_url", "type", "width", "height"},
-        )
 
-    def test_meta(self):
-        meta = ogp.to_meta(self.properties)
-        with open(os.path.join(HERE, "ogp-minotaur-shock.html")) as fh:
-            expected = fh.read().strip()
-        self.assertEqual(meta, expected)
+def test_invalid(ogp_properties):
+    _, parsed = ogp_properties
+    assert len(list(ogp.find(parsed, "audio"))) == 0
+
+
+def test_video(ogp_properties):
+    _, parsed = ogp_properties
+    videos = list(ogp.find(parsed, "video"))
+    assert len(videos) == 1
+    assert videos[0].value == videos[0].metadata["secure_url"]
+    assert set(videos[0].metadata.keys()) == {"secure_url", "type", "width", "height"}
+
+
+def test_meta(ogp_properties):
+    _, parsed = ogp_properties
+    with open(os.path.join(HERE, "ogp-minotaur-shock.html")) as fh:
+        expected = fh.read().strip()
+    meta = ogp.to_meta(parsed)
+    assert meta == expected

--- a/tests/test_opml.py
+++ b/tests/test_opml.py
@@ -1,47 +1,47 @@
 import datetime
 import os.path
-import unittest
+
+import pytest
 
 from adjunct import opml
 
 HERE = os.path.dirname(__file__)
 
 
-class OPMLTest(unittest.TestCase):
-    def test_parse_file(self):
-        with open(os.path.join(HERE, "sample.opml")) as fh:
-            doc = opml.parse(fh)
+def test_parse_file():
+    with open(os.path.join(HERE, "sample.opml")) as fh:
+        doc = opml.parse(fh)
 
-        assert doc is not None
-        self.assertTrue(doc.root)
-        self.assertEqual(len(doc.attrs), 1)
-        self.assertEqual(doc.attrs["title"], "Sample OPML file")
-        self.assertEqual(len(doc), 3)
+    assert doc is not None
+    assert doc.root
+    assert len(doc.attrs) == 1
+    assert doc.attrs["title"] == "Sample OPML file"
+    assert len(doc) == 3
 
-        # Check the top-level categories.
-        self.assertEqual(len(doc[0]), 2)
-        self.assertEqual(len(doc[1]), 1)
-        self.assertEqual(len(doc[2]), 1)
+    # Check the top-level categories.
+    assert len(doc[0]) == 2
+    assert len(doc[1]) == 1
+    assert len(doc[2]) == 1
 
-        # Check the last category and the one feed within it.
-        self.assertEqual(doc[2].attrs["text"], "Personal")
-        cant_hack = doc[2][0]
-        # 5, because it includes isComment and isBreakpoint implicitly
-        self.assertEqual(len(cant_hack.attrs), 5)
-        self.assertEqual(len(cant_hack), 0)
-        self.assertEqual(cant_hack.attrs["text"], "Can't Hack")
-        self.assertEqual(cant_hack.attrs["type"], "rss")
-        self.assertEqual(cant_hack.attrs["xmlUrl"], "https://i.canthack.it/feeds/all.xml")
-        self.assertEqual(cant_hack.attrs["isComment"], "false")
-        self.assertEqual(cant_hack.attrs["isBreakpoint"], "false")
+    # Check the last category and the one feed within it.
+    assert doc[2].attrs["text"] == "Personal"
+    cant_hack = doc[2][0]
+    # 5, because it includes isComment and isBreakpoint implicitly
+    assert len(cant_hack.attrs) == 5
+    assert len(cant_hack) == 0
+    assert cant_hack.attrs["text"] == "Can't Hack"
+    assert cant_hack.attrs["type"] == "rss"
+    assert cant_hack.attrs["xmlUrl"] == "https://i.canthack.it/feeds/all.xml"
+    assert cant_hack.attrs["isComment"] == "false"
+    assert cant_hack.attrs["isBreakpoint"] == "false"
 
-    def test_exception(self):
-        with self.assertRaises(opml.OpmlError):
-            opml.parse_string('<?xml version="1.0" encoding="UTF-8"?><opml version="1.0"><outline/></opml>')
 
-    def test_date_parse(self):
-        # Note: the resulting date is in UTC.
-        self.assertEqual(
-            opml.parse_timestamp("Fri, 21 Nov 1997 09:55:06 -0600"),
-            datetime.datetime(1997, 11, 21, 15, 55, 6, tzinfo=datetime.UTC),
-        )
+def test_exception():
+    with pytest.raises(opml.OpmlError):
+        opml.parse_string('<?xml version="1.0" encoding="UTF-8"?><opml version="1.0"><outline/></opml>')
+
+
+def test_date_parse():
+    # Note: the resulting date is in UTC.
+    expected = datetime.datetime(1997, 11, 21, 15, 55, 6, tzinfo=datetime.UTC)
+    assert opml.parse_timestamp("Fri, 21 Nov 1997 09:55:06 -0600") == expected

--- a/tests/test_passkit.py
+++ b/tests/test_passkit.py
@@ -6,6 +6,7 @@ import pytest
 from adjunct import passkit
 
 
+@pytest.mark.slow
 def test_jsonpasswdfile(tmp_path):
     ht = passkit.JSONPasswdFile(tmp_path / "passwd.json")
 
@@ -31,6 +32,7 @@ def test_jsonpasswdfile(tmp_path):
     assert set(ht.users.keys()) == {"barney"}
 
 
+@pytest.mark.slow
 def test_jsonpasswdfile_existing():
     path = os.path.join(os.path.dirname(__file__), "passwd.json")
     ht = passkit.JSONPasswdFile(path)

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -113,7 +113,7 @@ def check_vector(key: bytes, alg: str, now: int, expected: str):
 
 
 @pytest.mark.parametrize(
-    "now,expected",
+    ("now", "expected"),
     [
         (59, "94287082"),
         (1111111109, "07081804"),
@@ -133,7 +133,7 @@ def test_sha1_vectors(now: int, expected: str):
 
 
 @pytest.mark.parametrize(
-    "now,expected",
+    ("now", "expected"),
     [
         (59, "46119246"),
         (1111111109, "68084774"),
@@ -153,7 +153,7 @@ def test_sha256_vectors(now: int, expected: str):
 
 
 @pytest.mark.parametrize(
-    "now,expected",
+    ("now", "expected"),
     [
         (59, "90693936"),
         (1111111109, "25091201"),

--- a/tests/test_xmlutils.py
+++ b/tests/test_xmlutils.py
@@ -1,47 +1,47 @@
 import io
-import unittest
 
 from adjunct.xmlutils import XMLBuilder
 
 
-class XMLBuilderTest(unittest.TestCase):
-    def test_basics(self):
-        xml = XMLBuilder()
-        self.assertIsNotNone(xml.buffer)
-        with xml.within("root", xmlns="tag:talideon.com,2013:test"):
-            xml += "Before"
-            with xml.within("leaf"):
-                xml += "Within"
-            xml += "After"
-            xml.tag("leaf", "Another")
-        self.assertEqual(
-            xml.as_string(),
-            """<?xml version="1.0" encoding="utf-8"?>
-<root xmlns="tag:talideon.com,2013:test">Before<leaf>Within</leaf>After<leaf>Another</leaf></root>""",
-        )
-        xml.close()
-        self.assertIsNone(xml.buffer)
+def test_basics():
+    xml = XMLBuilder()
+    assert xml.buffer is not None
+    with xml.within("root", xmlns="tag:talideon.com,2013:test"):
+        xml += "Before"
+        with xml.within("leaf"):
+            xml += "Within"
+        xml += "After"
+        xml.tag("leaf", "Another")
+    assert (
+        xml.as_string()
+        == """<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="tag:talideon.com,2013:test">Before<leaf>Within</leaf>After<leaf>Another</leaf></root>"""
+    )
+    xml.close()
+    assert xml.buffer is None
 
-    def test_own_buffer(self):
-        buf = io.StringIO()
-        xml = XMLBuilder(buf)
-        self.assertIsNone(xml.buffer)
-        with xml.within("root", xmlns="myns"):
-            xml += "Body"
-        self.assertEqual(xml.as_string(), "")
-        self.assertEqual(
-            buf.getvalue(),
-            """<?xml version="1.0" encoding="utf-8"?>
-<root xmlns="myns">Body</root>""",
-        )
-        xml.close()
 
-    def test_attrs(self):
-        xml = XMLBuilder()
-        xml.root(xmlns="myns")
-        self.assertEqual(
-            xml.as_string(),
-            """<?xml version="1.0" encoding="utf-8"?>
-<root xmlns="myns"></root>""",
-        )
-        xml.close()
+def test_own_buffer():
+    buf = io.StringIO()
+    xml = XMLBuilder(buf)
+    assert xml.buffer is None
+    with xml.within("root", xmlns="myns"):
+        xml += "Body"
+    assert xml.as_string() == ""
+    assert (
+        buf.getvalue()
+        == """<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="myns">Body</root>"""
+    )
+    xml.close()
+
+
+def test_attrs():
+    xml = XMLBuilder()
+    xml.root(xmlns="myns")
+    assert (
+        xml.as_string()
+        == """<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="myns"></root>"""
+    )
+    xml.close()


### PR DESCRIPTION
All that remain are the ones using mocks. Also, I can now mark tests as slow and get a report on which ones aren't marked as such that maybe should be.

## Summary by Sourcery

Convert remaining unittest-based tests to pytest style and add support for marking and running slow tests separately.

Enhancements:
- Add an .editorconfig file to standardize editor behavior across the project.

Build:
- Add justfile commands to run only fast tests and to report the slowest unmarked tests for performance analysis.

Tests:
- Migrate HTML, oEmbed, XML utilities, OPML, discovery, OGP, and TOTP tests from unittest.TestCase classes to plain pytest tests and parametrization.
- Introduce shared pytest fixtures for HTTP-based discovery tests and refactor test server setup to use them.
- Mark JSONPasswdFile tests as slow and configure a pytest 'slow' marker for selective test execution.