### PR TITLE
Fix coverage in passkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ exclude_lines = [
   "raise NotImplementedError",
   "if 0:",
   "if __name__ == .__main__.:",
-  "pass",
+  "^\\s*pass\\s*$",
   "^\\s*\\.\\.\\.\\s*$",
 ]
 

--- a/src/adjunct/passkit.py
+++ b/src/adjunct/passkit.py
@@ -215,7 +215,7 @@ class JSONPasswdFile:
         return False
 
 
-def make_parser() -> argparse.ArgumentParser:  # pragma; no cover
+def make_parser() -> argparse.ArgumentParser:  # pragma: no cover
     parser = argparse.ArgumentParser(description="jsonpasswd editor")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--list", action="store_true", help="List users")


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Refine coverage exclusion pattern to only ignore standalone pass statements.