### PR TITLE
Add tests for some bits I haven't bothered to cover yet

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,5 +25,6 @@ jobs:
         with:
           version: "0.9.5"
           python-version: "3.11"
+          enable-cache: true
       - name: Deploy site
         run: uv run mkdocs gh-deploy --force

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,5 +41,6 @@ jobs:
         with:
           version: "0.9.5"
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
       - name: Run tests
         run: uv run --frozen pytest

--- a/src/adjunct/fixtureutils.py
+++ b/src/adjunct/fixtureutils.py
@@ -146,7 +146,7 @@ class _FakeSocket:
         self._body = io.BytesIO(body)
 
     def makefile(self, mode, bufsize=None):  # noqa: ARG002
-        if mode != "rb":
+        if mode != "rb":  # pragma: no cover
             raise client.UnimplementedFileMode()  # noqa: RSE102
         return self._body
 

--- a/src/adjunct/ogp.py
+++ b/src/adjunct/ogp.py
@@ -1,5 +1,4 @@
-"""
-An intensely pragmatic implementation of the Open Graph Protocol.
+"""An intensely pragmatic implementation of the Open Graph Protocol.
 
 This follows [the specification](https://opengraphprotocol.org/) rather than
 attempting to implement RDFa.
@@ -30,6 +29,14 @@ import typing as t
 
 @dataclasses.dataclass
 class Property:
+    """Open Graph Property.
+
+    Attributes:
+        type_: The property type (e.g., "title", "image", etc.).
+        value: The property value.
+        metadata: A mapping of metadata keys to values.
+    """
+
     type_: str
     value: str
     metadata: dict[str, str]
@@ -44,9 +51,20 @@ class Property:
         )
         return "\n".join(lines)
 
+    def __str__(self) -> str:
+        return self.to_meta()
 
-def parse(properties: t.Collection[tuple[str, str]]) -> t.Sequence[Property]:
-    """"""
+
+def parse(properties: t.Collection[tuple[str, str]]) -> list[Property]:
+    """Parse Open Graph properties from a list of name-value pairs.
+
+    Args:
+        properties: A collection of (name, value) pairs representing Open Graph
+            properties.
+
+    Returns:
+        The `Property` instances.
+    """
     result = []
     for name, value in properties:
         name_parts = name.split(":", 2)
@@ -61,7 +79,14 @@ def parse(properties: t.Collection[tuple[str, str]]) -> t.Sequence[Property]:
 
 
 def to_meta(props: Property | t.Sequence[Property]) -> str:
-    """"""
+    """Convert Open Graph properties to HTML meta tags.
+
+    Args:
+        props: A single `Property` instance or a sequence of `Property` instances.
+
+    Returns:
+        A string containing HTML meta tags representing the Open Graph properties.
+    """
     if isinstance(props, Property):
         return props.to_meta()
     return "\n".join(prop.to_meta() for prop in props)
@@ -72,7 +97,16 @@ def find(
     type_: str,
     value: str | None = None,
 ) -> t.Iterable[Property]:
-    """"""
+    """Find Open Graph properties by type and optional value.
+
+    Args:
+        props: A sequence of `Property` instances to search.
+        type_: The property type to search for.
+        value: An optional property value to match.
+
+    Returns:
+        An iterable of `Property` instances that match the specified type and value.
+    """
     for prop in props:
         if prop.type_ == type_ and (value is None or prop.value == value):
             yield prop

--- a/tests/test_fixtureutils.py
+++ b/tests/test_fixtureutils.py
@@ -126,3 +126,21 @@ def test_read_json_malformed_json():
     }
     with pytest.raises(json.JSONDecodeError):
         fixtureutils.read_json(env)
+
+
+def test_basic_response():
+    response_status = ""
+    response_headers = []
+
+    def start_response(status, headers):
+        nonlocal response_status, response_headers
+        response_status = status
+        response_headers = headers
+
+    body = "Hello, World!"
+    result = fixtureutils.basic_response(start_response, 200, body)
+
+    assert b"".join(result) == body.encode("utf-8")
+    assert response_status.startswith("200")
+    headers_dict = dict(response_headers)
+    assert headers_dict["Content-Length"] == str(len(body.encode("utf-8")))

--- a/tests/test_ogp.py
+++ b/tests/test_ogp.py
@@ -69,6 +69,11 @@ def test_single_property_to_meta():
     assert meta == expected
 
 
+def test_to_meta_empty_sequence():
+    meta = ogp.to_meta([])
+    assert meta == ""
+
+
 def test_bad_metadata_handling():
     properties = [
         ("og:title", "Example Title"),

--- a/tests/test_ogp.py
+++ b/tests/test_ogp.py
@@ -40,7 +40,45 @@ def test_video(ogp_properties):
 
 def test_meta(ogp_properties):
     _, parsed = ogp_properties
+    meta = ogp.to_meta(parsed)
     with open(os.path.join(HERE, "ogp-minotaur-shock.html")) as fh:
         expected = fh.read().strip()
-    meta = ogp.to_meta(parsed)
     assert meta == expected
+
+
+def test_str(ogp_properties):
+    _, parsed = ogp_properties
+    first = parsed[0]
+    assert str(first) == first.to_meta()
+
+
+def test_single_property_to_meta():
+    prop = ogp.Property(
+        type_="title",
+        value="Example Title",
+        metadata={"lang": "en", "alternate": "true"},
+    )
+    meta = ogp.to_meta(prop)
+    expected = "\n".join(  # noqa: FLY002
+        [
+            '<meta property="og:title" content="Example Title">',
+            '<meta property="og:title:lang" content="en">',
+            '<meta property="og:title:alternate" content="true">',
+        ]
+    )
+    assert meta == expected
+
+
+def test_bad_metadata_handling():
+    properties = [
+        ("og:title", "Example Title"),
+        ("og:title:lang", "en"),
+        ("og:description:badmeta", "This should be ignored"),
+        ("og:description", "An example description."),
+    ]
+    parsed = ogp.parse(properties)
+    assert len(parsed) == 2
+    assert parsed[0].type_ == "title"
+    assert parsed[0].metadata == {"lang": "en"}
+    assert parsed[1].type_ == "description"
+    assert parsed[1].metadata == {}

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -1,0 +1,44 @@
+import multiprocessing
+import time
+
+import pytest
+
+from adjunct import singleton
+
+
+def test_mutex():
+    with singleton.mutex(__file__):  # noqa: SIM117
+        with pytest.raises(singleton.MutexError):
+            with singleton.mutex(__file__):
+                pass
+
+
+def test_mutex_in_two_processes(tmp_path):
+    sem = multiprocessing.Semaphore(1)
+
+    def worker(filename: str, result_queue: multiprocessing.Queue):
+        try:
+            with singleton.mutex(filename):
+                if sem.acquire(timeout=0.0125):
+                    time.sleep(0.025)  # Hold the lock for a bit
+                    sem.release()
+            result_queue.put(1)
+        except singleton.MutexError:
+            result_queue.put(0)
+
+    filename = tmp_path / "mutexfile"
+    filename.touch()
+
+    result_queue = multiprocessing.Queue()
+    p1 = multiprocessing.Process(target=worker, args=(str(filename), result_queue))
+    p2 = multiprocessing.Process(target=worker, args=(str(filename), result_queue))
+
+    p1.start()
+    p2.start()
+
+    p1.join()
+    p2.join()
+
+    results = [result_queue.get() for _ in range(2)]
+    assert results.count(1) == 1
+    assert results.count(0) == 1

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -13,25 +13,31 @@ def test_mutex():
                 pass
 
 
+def worker(
+    filename: str,
+    result_queue: multiprocessing.Queue,
+    sem,
+):
+    delay = 0.0125  # Tunable, if it needs to be
+    try:
+        with singleton.mutex(filename):
+            if sem.acquire(timeout=delay):
+                time.sleep(delay * 2)  # Hold the lock for a bit
+                sem.release()
+        result_queue.put(1)
+    except singleton.MutexError:
+        result_queue.put(0)
+
+
 def test_mutex_in_two_processes(tmp_path):
-    sem = multiprocessing.Semaphore(1)
-
-    def worker(filename: str, result_queue: multiprocessing.Queue):
-        try:
-            with singleton.mutex(filename):
-                if sem.acquire(timeout=0.0125):
-                    time.sleep(0.025)  # Hold the lock for a bit
-                    sem.release()
-            result_queue.put(1)
-        except singleton.MutexError:
-            result_queue.put(0)
-
     filename = tmp_path / "mutexfile"
     filename.touch()
 
+    sem = multiprocessing.Semaphore(1)
     result_queue = multiprocessing.Queue()
-    p1 = multiprocessing.Process(target=worker, args=(str(filename), result_queue))
-    p2 = multiprocessing.Process(target=worker, args=(str(filename), result_queue))
+    args = (str(filename), result_queue, sem)
+    p1 = multiprocessing.Process(target=worker, args=args)
+    p2 = multiprocessing.Process(target=worker, args=args)
 
     p1.start()
     p2.start()


### PR DESCRIPTION
Also some docs.

## Summary by Sourcery

Add documentation and convenience behavior to Open Graph utilities while expanding test coverage across OGP handling, fixture utilities, and process-safe singleton mutex behavior.

New Features:
- Expose a string representation for Open Graph Property that renders its HTML meta tags.

Enhancements:
- Document Open Graph Property and related helper functions with descriptive docstrings.
- Mark unsupported file modes in the fake socket makefile as intentionally uncovered in tests.

Tests:
- Extend OGP tests to cover meta tag generation, Property string conversion, and handling of malformed metadata.
- Add tests for the basic_response helper to validate status, headers, and body encoding.
- Introduce tests for the singleton mutex to verify mutual exclusion within a process and across multiple processes.