### PR TITLE
Fix an overly broad return type

### DIFF
--- a/src/adjunct/discoverfeeds.py
+++ b/src/adjunct/discoverfeeds.py
@@ -1,7 +1,5 @@
 """Feed discovery."""
 
-import typing as t
-
 from . import discovery
 
 __all__ = ["discover_feeds"]
@@ -81,7 +79,7 @@ class _FeedExtractor(discovery.Extractor):
             self.added.add(attrs["href"])
 
 
-def discover_feeds(url: str) -> t.Collection[dict[str, str]]:
+def discover_feeds(url: str) -> list[dict[str, str]]:
     """Discover any feeds at the given URL.
 
     Args:


### PR DESCRIPTION
## Summary by Sourcery

Broaden the discover_feeds return type annotation and remove an unused typing import.

Enhancements:
- Widen the discover_feeds return type from a generic collection to a concrete list of feed metadata dictionaries.
- Clean up an unused typing module import from the feed discovery module.