### PR TITLE
Produce a coverage report on PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+# https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,8 +37,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Check out the PR head commit (not the merge commit) so coverage line numbers map correctly to the diff.
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@v6
@@ -48,29 +46,4 @@ jobs:
           enable-cache: true
 
       - name: Run tests
-        run: uv run --frozen pytest --cov=adjunct --cov-report=xml --cov-report=term
-
-      - uses: actions/upload-artifact@v4
-        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.python-version == '3.14'
-        with:
-          name: coverage-report
-          path: coverage.xml
-
-  upload-coverage:
-    needs: test
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      code-quality: write
-
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: coverage-report
-
-      - uses: actions/upload-code-coverage@v1
-        with:
-          file: coverage.xml
-          language: python
-          label: code-coverage/pytest
+        run: uv run --frozen pytest --cov=adjunct --cov-report=term

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        # Check out the PR head commit (not the merge commit) so coverage line numbers map correctly to the diff.
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
         with:
           persist-credentials: false
 
@@ -56,7 +58,7 @@ jobs:
 
   upload-coverage:
     needs: test
-    if: ${{ !cancelled() && needs.test.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -71,4 +73,4 @@ jobs:
         with:
           file: coverage.xml
           language: python
-          label: code-coverage/adjunct
+          label: code-coverage/pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+
       - uses: astral-sh/ruff-action@v3
         with:
           version: "0.14.3"
@@ -37,10 +38,37 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+
       - uses: astral-sh/setup-uv@v6
         with:
           version: "0.9.5"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+
       - name: Run tests
-        run: uv run --frozen pytest
+        run: uv run --frozen pytest --cov=adjunct --cov-report=xml --cov-report=term
+
+      - uses: actions/upload-artifact@v4
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.python-version == "3.14"
+        with:
+          name: coverage-report
+          path: coverage.xml
+
+  upload-coverage:
+    needs: test
+    if: ${{ !cancelled() && needs.build.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+
+      - uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage.xml
+          language: python
+          label: code-coverage/adjunct

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
 
   upload-coverage:
     needs: test
-    if: ${{ !cancelled() && needs.build.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ !cancelled() && needs.test.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         run: uv run --frozen pytest --cov=adjunct --cov-report=xml --cov-report=term
 
       - uses: actions/upload-artifact@v4
-        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.python-version == "3.14"
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.python-version == '3.14'
         with:
           name: coverage-report
           path: coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,9 +36,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-        # Check out the PR head commit (not the merge commit) so coverage line numbers map correctly to the diff.
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
         with:
+          # Check out the PR head commit (not the merge commit) so coverage line numbers map correctly to the diff.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@v6

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 
 # Unit test / coverage reports
 .coverage*
+coverage.xml
 htmlcov/
 results.xml
 .*_cache/

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ test-show-slow:
 # run the tests with coverage
 [group("Testing")]
 coverage:
-	@uv run --frozen pytest --cov=adjunct --cov-report=html
+	@uv run --frozen pytest --cov=adjunct --cov-report=html --cov-report=xml --cov-report=term
 
 # run the typechecker
 [group("Analysis/Fixing")]


### PR DESCRIPTION
## Summary by Sourcery

Enable test coverage reporting in CI and configure automated updates for GitHub Actions dependencies.

New Features:
- Generate XML and terminal coverage reports during pytest runs in CI and local coverage task.
- Upload coverage artifacts from CI and publish coverage data via the upload-code-coverage action.

CI:
- Extend tests workflow to produce coverage artifacts and publish coverage results for PRs.
- Restrict coverage upload to trusted pull requests and a specific Python version matrix entry.

Tests:
- Update justfile coverage task to emit HTML, XML, and terminal coverage reports for the test suite.

Chores:
- Add Dependabot configuration to keep GitHub Actions dependencies up to date.