### PR TITLE
Update dependencies and turn on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+# https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: true
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "0.11.23"
           python-version: "3.11"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,12 +18,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           persist-credentials: true
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v8
         with:
-          version: "0.9.5"
+          version: "0.11.23"
           python-version: "3.11"
           enable-cache: true
       - name: Deploy site

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: astral-sh/ruff-action@v3
+
+      - uses: astral-sh/ruff-action@v4
         with:
-          version: "0.14.3"
+          version: "0.15.18"
 
   test:
     runs-on: ubuntu-latest
@@ -34,13 +35,15 @@ jobs:
           - "3.14"
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+
+      - uses: astral-sh/setup-uv@v8
         with:
-          version: "0.9.5"
+          version: "0.11.23"
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+
       - name: Run tests
         run: uv run --frozen pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: astral-sh/ruff-action@v4
+      - uses: astral-sh/ruff-action@v4.0.0
         with:
           version: "0.15.18"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "0.11.23"
           python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ ignore = [
   "EM101",   # Exceptions must not use strings
   "EM102",   # Exception must not use f-string literal
   "TRY003",  # Avoid specifying long messages outside the exception class
+  "PYI034",  # `__enter__` methods in classes like ??? usually return `self` at runtime (disabled for compatibility)
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflows to use newer GitHub Actions and tooling versions and enable automated dependency updates for GitHub Actions via Dependabot.

CI:
- Bump actions/checkout, astral-sh/ruff-action, and astral-sh/setup-uv to newer major/minor versions in test and docs workflows.
- Adjust ruff lint configuration to ignore rule PYI034 for compatibility.
- Add a Dependabot configuration to manage GitHub Actions updates on a weekly schedule.