### PR TITLE
Show coverage at the end of a test run in the terminal

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,4 +46,4 @@ jobs:
           enable-cache: true
 
       - name: Run tests
-        run: uv run --frozen pytest
+        run: uv run --frozen pytest --cov=adjunct --cov-report=term

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 
 # Unit test / coverage reports
 .coverage*
+coverage.xml
 htmlcov/
 results.xml
 .*_cache/

--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ test-show-slow:
 # run the tests with coverage
 [group("Testing")]
 coverage:
-	@uv run --frozen pytest --cov=adjunct --cov-report=html
+	@uv run --frozen pytest --cov=adjunct --cov-report=html --cov-report=term
 
 # run the typechecker
 [group("Analysis/Fixing")]


### PR DESCRIPTION
## Summary by Sourcery

Show test coverage summaries in the terminal for both CI and local coverage runs.

Tests:
- Update CI test workflow to run pytest with coverage enabled and print a terminal coverage report.
- Extend the coverage just task to output coverage to both HTML and the terminal.