### PR TITLE
Fix type error in XMLBuilder constructor

### DIFF
--- a/src/adjunct/xmlutils.py
+++ b/src/adjunct/xmlutils.py
@@ -2,7 +2,6 @@
 
 import contextlib
 import io
-import typing as t
 from xml.sax import saxutils
 
 
@@ -33,7 +32,7 @@ class XMLBuilder:
         string as no other sensible value can be returned.
     """
 
-    def __init__(self, out: t.TextIO | None = None, encoding: str = "utf-8") -> None:
+    def __init__(self, out: io.TextIOBase | None = None, encoding: str = "utf-8") -> None:
         self.buffer = None
         if out is None:
             self.buffer = io.StringIO()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix type annotation of the XMLBuilder constructor output parameter to use io.TextIOBase instead of a generic text I/O type.